### PR TITLE
[MOBILE-177] android SDK 9.3, FCM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ One of our engineers will verify receipt of the agreement before approving your 
 Please visit http://support.urbanairship.com/ for any issues integrating or using this plugin.
 
 ### Requirements:
- - Cordova-CLI >= 6.4.0
+ - Cordova-CLI >= 7.0.0
  - Android [GCM Setup](http://docs.urbanairship.com/reference/push-providers/gcm.html#android-gcm-setup)
  - iOS [APNS Setup](http://docs.urbanairship.com/reference/push-providers/apns.html)
 
@@ -41,9 +41,6 @@ the GCM/FCM sender ID either needs to be prefixed with `sender:` or you can disa
         <preference name="com.urbanairship.production_app_secret" value="Your Production App Secret" />
         <preference name="com.urbanairship.development_app_key" value="Your Development App Key" />
         <preference name="com.urbanairship.development_app_secret" value="Your Development App Secret" />
-
-        <!-- Required for Android. -->
-        <preference name="com.urbanairship.gcm_sender" value="sender:Your GCM Sender ID" />
 
         <!-- If the app is in production or not -->
         <preference name="com.urbanairship.in_production" value="true | false" />
@@ -90,7 +87,14 @@ the GCM/FCM sender ID either needs to be prefixed with `sender:` or you can disa
         <!-- iOS 10 sound foreground notification presentation option -->
         <preference name="com.urbanairship.ios_foreground_notification_presentation_sound" value="true | false"/>
 
-3. *(iOS Only)* Add your Apple Developer Account Team ID to the [build.json](https://cordova.apache.org/docs/en/latest/guide/platforms/ios/#using-buildjson):
+3. *(Android Only)* Add a reference to your google-servies.json file (parallel to config.xml):
+
+       <platform name="android">
+            ...
+            <resource-file src="google-services.json" target="app/google-services.json" />
+       </platform>
+
+4. *(iOS Only)* Add your Apple Developer Account Team ID to the [build.json](https://cordova.apache.org/docs/en/latest/guide/platforms/ios/#using-buildjson):
 
         {
             "ios": {

--- a/config_sample.xml
+++ b/config_sample.xml
@@ -28,8 +28,6 @@
 <preference name="com.urbanairship.production_app_secret" value="APP_SECRET_PLACEHOLDER" />
 <preference name="com.urbanairship.development_app_key" value="APP_KEY_PLACEHOLDER" />
 <preference name="com.urbanairship.development_app_secret" value="APP_SECRET_PLACEHOLDER" />
-<!-- Required for Android. -->
-<preference name="com.urbanairship.gcm_sender" value="GCM_SENDER_ID_PLACEHOLDER" />
 <!-- If the app is in production or not -->
 <preference name="com.urbanairship.in_production" value="false" />
 <!-- Optional config values -->

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -19,10 +19,9 @@ allprojects {
 }
 
 dependencies {
+    implementation 'com.google.firebase:firebase-core:16.0.0
     compile 'com.android.support:support-v4:27.1.1'
     compile 'com.android.support:support-annotations:27.1.1'
-    compile 'com.google.android.gms:play-services-gcm:15.0.1'
-    compile 'com.android.support:cardview-v7:27.1.1'
     compile 'com.google.android.gms:play-services-location:15.0.1'
     compile 'com.android.support:appcompat-v7:27.1.1'
     compile 'com.urbanairship.android:urbanairship-fcm:9.3.0'

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,16 +1,33 @@
-repositories {
-    jcenter()
-    maven {
-        url "https://maven.google.com"
+
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.google.gms:google-services:4.0.1'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        jcenter()
     }
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:[27.0.2,28)'
-    compile 'com.android.support:support-annotations:[27.0.2,28)'
-    compile 'com.google.android.gms:play-services-gcm:[11.8.0,12)'
-    compile 'com.android.support:cardview-v7:[27.0.2,28)'
-    compile 'com.google.android.gms:play-services-location:[11.8.0,12)'
-    compile 'com.android.support:appcompat-v7:[27.0.2,28)'
-    compile 'com.urbanairship.android:urbanairship-sdk:9.0.2'
+    compile 'com.android.support:support-v4:27.1.1'
+    compile 'com.android.support:support-annotations:27.1.1'
+    compile 'com.google.android.gms:play-services-gcm:15.0.1'
+    compile 'com.android.support:cardview-v7:27.1.1'
+    compile 'com.google.android.gms:play-services-location:15.0.1'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.urbanairship.android:urbanairship-fcm:9.3.0'
+}
+
+ext.postBuildExtras = {
+    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
 }


### PR DESCRIPTION
I had to do some gradle magic to make this work, but it seems to do the trick. This makes FCM the default going forward, and also does away with the need for users to prefix the sender ID because google-services.json should have all the credendtials they need. Also bumping the cordova command line tool requirements to 7.0, due to changes in android app structure that complicate the specification of resource files.

