### PR TITLE
[MOBILE-200] title and subtitle, aps push event fields

### DIFF
--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -841,6 +841,8 @@ public class UAirshipPlugin extends CordovaPlugin {
 
         try {
             data.putOpt("message", message.getAlert());
+            data.putOpt("title", message.getTitle());
+            data.putOpt("subtitle", message.getSummary());
             data.putOpt("extras", new JSONObject(extras));
             data.putOpt("notification_id", notificationId);
         } catch (JSONException e) {

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -965,20 +965,32 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
         return @{ @"message": @"", @"extras": @{}};
     }
 
-    // remove extraneous key/value pairs
-    NSMutableDictionary *extras = [NSMutableDictionary dictionaryWithDictionary:notificationContent.notificationInfo];
+    NSMutableDictionary *info = [NSMutableDictionary dictionaryWithDictionary:notificationContent.notificationInfo];
 
-    if([[extras allKeys] containsObject:@"aps"]) {
-        [extras removeObjectForKey:@"aps"];
-    }
-
-    if([[extras allKeys] containsObject:@"_"]) {
-        [extras removeObjectForKey:@"_"];
+    // remove the send ID
+    if([[info allKeys] containsObject:@"_"]) {
+        [info removeObjectForKey:@"_"];
     }
 
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
+
+    // If there is an aps dictionary in the extras, remove it and set it as a top level object
+    if([[info allKeys] containsObject:@"aps"]) {
+        result[@"aps"] = info[@"aps"];
+        [info removeObjectForKey:@"aps"];
+    }
+
     result[@"message"] = notificationContent.alertBody ?: @"";
-    result[@"extras"] = extras;
+
+    // Set the title and subtitle as top level objects, if present
+    NSString *title = notificationContent.alertTitle;
+    NSString *subtitle = notificationContent.notification.request.content.subtitle;
+    [result setValue:title forKey:@"title"];
+    [result setValue:subtitle forKey:@"subtitle"];
+
+    // Set the remaining info as extras
+    result[@"extras"] = info;
+
     return result;
 }
 

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -143,7 +143,7 @@ module.exports = {
   /**
    * Event fired when a new deep link is received.
    *
-   * @event urbanairship.deep_link
+   * @event UrbanAirship#deep_link
    * @type {object}
    * @param {string} [deepLink] The deep link.
    */
@@ -151,7 +151,7 @@ module.exports = {
   /**
    * Event fired when a channel registration occurs.
    *
-   * @event urbanairship.registration
+   * @event UrbanAirship#registration
    * @type {object}
    * @param {string} [channelID] The channel ID.
    * @param {string} [registrationToken] The deviceToken on iOS, and the FCM/ADM token on Android.
@@ -161,23 +161,26 @@ module.exports = {
   /**
    * Event fired when the inbox is updated.
    *
-   * @event urbanairship.inbox_updated
+   * @event UrbanAirship#inbox_updated
    */
 
   /**
    * Event fired when a push is received.
    *
-   * @event urbanairship.push
+   * @event UrbanAirship#push
    * @type {object}
    * @param {string} message The push alert message.
+   * @param {string} title The push title.
+   * @param {string} subtitle The push subtitle.
    * @param {object} extras Any push extras.
+   * @param {object} aps The raw aps dictionary (iOS only)
    * @param {number} [notification_id] The Android notification ID.
    */
 
   /**
    * Event fired when notification opened.
    *
-   * @event urbanairship.notification_opened
+   * @event UrbanAirship#notification_opened
    * @type {object}
    * @param {string} message The push alert message.
    * @param {object} extras Any push extras.
@@ -186,17 +189,17 @@ module.exports = {
    * @param {boolean} isForeground Will always be true if the user taps the main notification. Otherwise its defined by the notificaiton action button.
    */
 
-   /**
-    * Event fired when the user notification opt-in status changes.
-    *
-    * @event urbanairship.notification_opt_in_status
-    * @type {object}
-    * @param {boolean} optIn If the user is opted in or not to user notifications.
-    * @param {object} [notificationOptions] iOS only. A map of opted in options.
-    * @param {boolean} notificationOptions.alert If the user is opted into alerts.
-    * @param {boolean} notificationOptions.sound If the user is opted into sounds.
-    * @param {boolean} notificationOptions.badge If the user is opted into badge updates.
-    */
+  /**
+   * Event fired when the user notification opt-in status changes.
+   *
+   * @event UrbanAirship#notification_opt_in_status
+   * @type {object}
+   * @param {boolean} optIn If the user is opted in or not to user notifications.
+   * @param {object} [notificationOptions] iOS only. A map of opted in options.
+   * @param {boolean} notificationOptions.alert If the user is opted into alerts.
+   * @param {boolean} notificationOptions.sound If the user is opted into sounds.
+   * @param {boolean} notificationOptions.badge If the user is opted into badge updates.
+   */
 
   /**
    * Re-attaches document event listeners in this webview


### PR DESCRIPTION
This is a PR that addresses the same stuff as https://github.com/urbanairship/urbanairship-cordova/pull/227, but with a structure we'd prefer.

* Adds title and subtitle to top level push event object. (subtitle maps to "summary" on android for historical reasons)
* APS dictionary on iOS now goes in its own top-level field as well, in case folks want access to the raw push data for whatever reason

Note: I'm not sure how best to document this change, aside from making a note in the CHANGELOG. Platform extdocs?