### PR TITLE
[MOBILE-199] generate push events from background push on iOS

### DIFF
--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -772,6 +772,16 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     completionHandler();
 }
 
+- (void)receivedBackgroundNotification:(UANotificationContent *)notificationContent
+                     completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+
+    UA_LDEBUG(@"Received a background notification %@", notificationContent);
+
+    id event = [self pushEventFromNotification:notificationContent];
+    [self notifyListener:EventPushReceived data:event];
+    completionHandler(UIBackgroundFetchResultNoData);
+}
+
 #pragma mark UAInboxDelegate
 
 - (void)showMessageForID:(NSString *)messageID {
@@ -959,7 +969,6 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     return YES;
 }
 
-
 - (NSDictionary *)pushEventFromNotification:(UANotificationContent *)notificationContent {
     if (!notificationContent) {
         return @{ @"message": @"", @"extras": @{}};
@@ -1015,7 +1024,6 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     }
     return defaultValue;
 }
-
 
 - (UANotificationAction *)notificationActionForCategory:(NSString *)category actionIdentifier:(NSString *)identifier {
     NSSet *categories = [UAirship push].combinedCategories;


### PR DESCRIPTION
This is just feature parity with the android plugin, so that background notifications will result in a push event getting created and enqueued into the JS layer. No SDK bindings were harmed in the making of this pull request.