### PR TITLE
[release-7.1] CHANGELOG, version bumps

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+
+=================================
+Version 7.1.0 - June 13, 2018
+=================================
+- Updated iOS SDK to 9.2.1
+- Updated Android SDK to 9.3.0
+- Added support for FCM on Android
+- Added support for loading custom notification categories
+- Notification event payloads now contain title and subtitle
+- iOS notification event payloads now contain a top level APS object with raw notification data
+- iOS background notifications now generate events
+- Plugin now requires Cordova 7.0. Earlier versions may work, but integration steps and
+  documentation assume Cordova 7.0 or higher moving forward.
+
 =================================
 Version 7.0.1 - March 8, 2018
 =================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "Urban Airship Cordova plugin",
   "cordova": {
     "id": "urbanairship-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -326,7 +326,7 @@
         <resource-file src="src/ios/Airship/AirshipResources.bundle"/>
 
         <!-- Airship library -->
-        <source-file framework="true" src="src/ios/Airship/libUAirship-9.2.0.a"/>
+        <source-file framework="true" src="src/ios/Airship/libUAirship-9.2.1.a"/>
 
         <!-- System frameworks -->
         <framework src="libsqlite3.dylib" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin id="urbanairship-cordova"
-        version="7.0.1"
+        version="7.1.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 


### PR DESCRIPTION
Note: I assume we're releasing iOS 9.2.1 today, and if so I'll make sure to drop the new iOS SDK in before pulling the trigger on this release. Otherwise, we can modify the CHANGELOG accordingly.