### PR TITLE
Android: Enable takeOff in JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "6.9.3",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "minami": "1.2.3"
   },
   "scripts": {
-    "generate-docs": "node_modules/.bin/jsdoc ./www/UrbanAirship.js -t ./node_modules/minami/ -r jsdoc_readme.md"
+    "generate-docs": "jsdoc ./www/UrbanAirship.js -t ./node_modules/minami/ -r jsdoc_readme.md"
   }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,6 +37,10 @@
                 android:name="com.urbanairship.autopilot"
                 android:value="com.urbanairship.cordova.CordovaAutopilot"/>
 
+            <meta-data
+                android:name="com.urbanairship.webview.ENABLE_LOCAL_STORAGE"
+                android:value="true" />
+
             <receiver
                 android:name="com.urbanairship.cordova.CordovaAirshipReceiver"
                 android:exported="false">
@@ -120,7 +124,10 @@
             src="src/android/CustomLandingPageActivity.java"
             target-dir="src/com/urbanairship/cordova"/>
         <source-file
-            src="src/android/UAirshipPluginManager.java"
+            src="src/android/PluginManager.java"
+            target-dir="src/com/urbanairship/cordova"/>
+        <source-file
+            src="src/android/PluginConfig.java"
             target-dir="src/com/urbanairship/cordova"/>
         <source-file
             src="src/android/events/RegistrationEvent.java"

--- a/src/android/CordovaAirshipReceiver.java
+++ b/src/android/CordovaAirshipReceiver.java
@@ -43,21 +43,21 @@ public class CordovaAirshipReceiver extends AirshipReceiver {
     @Override
     protected void onChannelCreated(Context context, String channelId) {
         Log.i(TAG, "Channel created. Channel ID: " + channelId + ".");
-        UAirshipPluginManager.shared().channelUpdated(channelId, true);
-        UAirshipPluginManager.shared().checkOptInStatus(context);
+        PluginManager.shared().channelUpdated(channelId, true);
+        PluginManager.shared().checkOptInStatus(context);
     }
 
     @Override
     protected void onChannelUpdated(Context context, String channelId) {
         Log.i(TAG, "Channel updated. Channel ID: " + channelId + ".");
-        UAirshipPluginManager.shared().channelUpdated(channelId, true);
-        UAirshipPluginManager.shared().checkOptInStatus(context);
+        PluginManager.shared().channelUpdated(channelId, true);
+        PluginManager.shared().checkOptInStatus(context);
     }
 
     @Override
     protected void onChannelRegistrationFailed(Context context) {
         Log.i(TAG, "Channel registration failed.");
-        UAirshipPluginManager.shared().channelUpdated(UAirship.shared().getPushManager().getChannelId(), false);
+        PluginManager.shared().channelUpdated(UAirship.shared().getPushManager().getChannelId(), false);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class CordovaAirshipReceiver extends AirshipReceiver {
 
 
         if (!notificationPosted) {
-            UAirshipPluginManager.shared().pushReceived(null, message);
+            PluginManager.shared().pushReceived(null, message);
         }
     }
 
@@ -74,14 +74,14 @@ public class CordovaAirshipReceiver extends AirshipReceiver {
     protected void onNotificationPosted(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
         Log.i(TAG, "Notification posted. Alert: " + notificationInfo.getMessage().getAlert() + ". NotificationId: " + notificationInfo.getNotificationId());
 
-        UAirshipPluginManager.shared().pushReceived(notificationInfo.getNotificationId(), notificationInfo.getMessage());
+        PluginManager.shared().pushReceived(notificationInfo.getNotificationId(), notificationInfo.getMessage());
     }
 
     @Override
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
         Log.i(TAG, "Notification opened. Alert: " + notificationInfo.getMessage().getAlert() + ". NotificationId: " + notificationInfo.getNotificationId());
 
-        UAirshipPluginManager.shared().notificationOpened(notificationInfo);
+        PluginManager.shared().notificationOpened(notificationInfo);
 
         // Return false here to allow Urban Airship to auto launch the launcher activity
         return false;
@@ -91,7 +91,7 @@ public class CordovaAirshipReceiver extends AirshipReceiver {
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo, @NonNull ActionButtonInfo actionButtonInfo) {
         Log.i(TAG, "Notification action button opened. Button ID: " + actionButtonInfo.getButtonId() + ". NotificationId: " + notificationInfo.getNotificationId());
 
-        UAirshipPluginManager.shared().notificationOpened(notificationInfo, actionButtonInfo);
+        PluginManager.shared().notificationOpened(notificationInfo, actionButtonInfo);
 
         // Return false here to allow Urban Airship to auto launch the launcher
         // activity for foreground notification action buttons

--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -1,40 +1,12 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova;
 
 import android.content.Context;
-import android.content.res.XmlResourceParser;
-import android.graphics.Color;
-import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.util.Log;
 
 import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.Autopilot;
-import com.urbanairship.Logger;
 import com.urbanairship.UAirship;
 import com.urbanairship.actions.Action;
 import com.urbanairship.actions.ActionArguments;
@@ -43,133 +15,62 @@ import com.urbanairship.actions.ActionResult;
 import com.urbanairship.actions.DeepLinkAction;
 import com.urbanairship.actions.OpenRichPushInboxAction;
 import com.urbanairship.actions.OverlayRichPushMessageAction;
-import com.urbanairship.push.notifications.DefaultNotificationFactory;
 import com.urbanairship.richpush.RichPushInbox;
-import com.urbanairship.util.UAStringUtil;
-
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
 
 /**
  * The Urban Airship autopilot to automatically handle takeOff.
  */
 public class CordovaAutopilot extends Autopilot {
 
-    private static final String SENDER_PREFIX = "sender:";
-
-    static final String UA_PREFIX = "com.urbanairship";
-    static final String PRODUCTION_KEY = "com.urbanairship.production_app_key";
-    static final String PRODUCTION_SECRET = "com.urbanairship.production_app_secret";
-    static final String DEVELOPMENT_KEY = "com.urbanairship.development_app_key";
-    static final String DEVELOPMENT_SECRET = "com.urbanairship.development_app_secret";
-    static final String PRODUCTION_LOG_LEVEL = "com.urbanairship.production_log_level";
-    static final String DEVELOPMENT_LOG_LEVEL = "com.urbanairship.development_log_level";
-    static final String IN_PRODUCTION = "com.urbanairship.in_production";
-    static final String GCM_SENDER = "com.urbanairship.gcm_sender";
-    static final String ENABLE_PUSH_ONLAUNCH = "com.urbanairship.enable_push_onlaunch";
-    static final String NOTIFICATION_ICON = "com.urbanairship.notification_icon";
-    static final String NOTIFICATION_LARGE_ICON = "com.urbanairship.notification_large_icon";
-    static final String NOTIFICATION_ACCENT_COLOR = "com.urbanairship.notification_accent_color";
-    static final String NOTIFICATION_SOUND = "com.urbanairship.notification_sound";
-    static final String AUTO_LAUNCH_MESSAGE_CENTER = "com.urbanairship.auto_launch_message_center";
-
-    // Enable/Disable features
-    static final String ENABLE_ANALYTICS = "com.urbanairship.enable_analytics";
-
-    private PluginConfig pluginConfig;
+    public static boolean isReady = false;
 
     @Override
     public AirshipConfigOptions createAirshipConfigOptions(Context context) {
-
-        PluginConfig pluginConfig = getPluginConfig(context);
-
-        AirshipConfigOptions options = new AirshipConfigOptions.Builder()
-                .setDevelopmentAppKey(pluginConfig.getString(DEVELOPMENT_KEY, ""))
-                .setDevelopmentAppSecret(pluginConfig.getString(DEVELOPMENT_SECRET, ""))
-                .setProductionAppKey(pluginConfig.getString(PRODUCTION_KEY, ""))
-                .setProductionAppSecret(pluginConfig.getString(PRODUCTION_SECRET, ""))
-                .setInProduction(pluginConfig.getBoolean(IN_PRODUCTION, false))
-                .setFcmSenderId(parseSender(pluginConfig.getString(GCM_SENDER, null)))
-                .setAnalyticsEnabled(pluginConfig.getBoolean(ENABLE_ANALYTICS, true))
-                .setDevelopmentLogLevel(parseLogLevel(pluginConfig.getString(DEVELOPMENT_LOG_LEVEL, ""), Log.DEBUG))
-                .setProductionLogLevel(parseLogLevel(pluginConfig.getString(PRODUCTION_LOG_LEVEL, ""), Log.ERROR))
-                .build();
-
-        return options;
+        return PluginConfig.shared(context).getAirshipConfig();
     }
 
+    @Override
+    public boolean isReady(@NonNull Context context) {
+        if (PluginConfig.shared(context).getAirshipConfig() != null) {
+            isReady = true;
+        }
+
+        return isReady;
+    }
 
     @Override
     public void onAirshipReady(UAirship airship) {
         Context context = UAirship.getApplicationContext();
-        PluginConfig pluginConfig = getPluginConfig(context);
+        PluginConfig pluginConfig = PluginConfig.shared(context);
 
-        final boolean enablePushOnLaunch = pluginConfig.getBoolean(ENABLE_PUSH_ONLAUNCH, false);
-        if (enablePushOnLaunch) {
-            airship.getPushManager().setUserNotificationsEnabled(enablePushOnLaunch);
+        if (pluginConfig.getEnablePushOnLaunch()) {
+            airship.getPushManager().setUserNotificationsEnabled(true);
         }
 
-        // Customize the notification factory
-        DefaultNotificationFactory factory = new DefaultNotificationFactory(context);
+        // Large Icon
+        airship.getPushManager()
+                .getNotificationFactory()
+                .setLargeIcon(pluginConfig.getNotificationLargeIcon());
 
-        // Accent color
-        String accentColor = pluginConfig.getString(NOTIFICATION_ACCENT_COLOR, null);
-        if (!UAStringUtil.isEmpty(accentColor)) {
-            try {
-                factory.setColor(Color.parseColor(accentColor));
-            } catch (IllegalArgumentException e) {
-                Logger.error("Unable to parse notification accent color: " + accentColor, e);
-            }
-        }
+        // Sound
+        airship.getPushManager()
+                .getNotificationFactory()
+                .setSound(pluginConfig.getNotificationSound());
 
-        // Notification icon
-        String notificationIconName = pluginConfig.getString(NOTIFICATION_ICON, null);
-        if (!UAStringUtil.isEmpty(notificationIconName)) {
-            int id = context.getResources().getIdentifier(notificationIconName, "drawable", context.getPackageName());
-            if (id != 0) {
-                factory.setSmallIconId(id);
-            } else {
-                Logger.error("Unable to find notification icon with name: " + notificationIconName);
-            }
-        }
-
-        // Notification large icon
-        String notificationLargeIconName = pluginConfig.getString(NOTIFICATION_LARGE_ICON, null);
-        if (!UAStringUtil.isEmpty(notificationLargeIconName)) {
-            int id = context.getResources().getIdentifier(notificationLargeIconName, "drawable", context.getPackageName());
-            if (id != 0) {
-                factory.setLargeIcon(id);
-            } else {
-                Logger.error("Unable to find notification large icon with name: " + notificationLargeIconName);
-            }
-        }
-
-        // Notification sound
-        String notificationSoundName = pluginConfig.getString(NOTIFICATION_SOUND, null);
-        if (!UAStringUtil.isEmpty(notificationSoundName)) {
-            int id = context.getResources().getIdentifier(notificationSoundName, "raw", context.getPackageName());
-            if (id > 0) {
-                Uri uri = Uri.parse("android.resource://" + context.getPackageName() + "/" + id);
-                factory.setSound(uri);
-            } else {
-                Logger.error("Unable to find notification sound with name: " + notificationSoundName);
-            }
-        }
-
+        // Deep link
         airship.getActionRegistry().getEntry(DeepLinkAction.DEFAULT_REGISTRY_NAME).setDefaultAction(new DeepLinkAction() {
             @Override
             public ActionResult perform(@NonNull ActionArguments arguments) {
                 String deepLink = arguments.getValue().getString();
                 if (deepLink != null) {
-                    UAirshipPluginManager.shared().deepLinkReceived(deepLink);
+                    PluginManager.shared().deepLinkReceived(deepLink);
                 }
                 return ActionResult.newResult(arguments.getValue());
             }
         });
 
-
-        final boolean autoLaunchMessageCenter = pluginConfig.getBoolean(AUTO_LAUNCH_MESSAGE_CENTER, true);
+        // Auto launch message center
+        final boolean autoLaunchMessageCenter = pluginConfig.getAutoLaunchMessageCenter();
         airship.getActionRegistry()
                 .getEntry(OverlayRichPushMessageAction.DEFAULT_REGISTRY_NAME)
                 .setPredicate(new ActionRegistry.Predicate() {
@@ -183,6 +84,7 @@ public class CordovaAutopilot extends Autopilot {
                     }
                 });
 
+        // Auto launch message center
         airship.getActionRegistry()
                 .getEntry(OpenRichPushInboxAction.DEFAULT_REGISTRY_NAME)
                 .setPredicate(new ActionRegistry.Predicate() {
@@ -196,151 +98,12 @@ public class CordovaAutopilot extends Autopilot {
                     }
                 });
 
-        airship.getPushManager().setNotificationFactory(factory);
-
-
-        UAirship.shared().getInbox().addListener(new RichPushInbox.Listener() {
+        // Inbox updates
+        airship.getInbox().addListener(new RichPushInbox.Listener() {
             @Override
             public void onInboxUpdated() {
-                UAirshipPluginManager.shared().inboxUpdated();
+                PluginManager.shared().inboxUpdated();
             }
         });
-    }
-
-    /**
-     * Gets the config for the Urban Airship plugin.
-     *
-     * @param context The application context.
-     * @return The plugin config.
-     */
-    public PluginConfig getPluginConfig(Context context) {
-        if (pluginConfig == null) {
-            pluginConfig = new PluginConfig(context);
-        }
-
-        return pluginConfig;
-    }
-
-    /**
-     * Convert the log level string to an int.
-     *
-     * @param logLevel The log level as a string.
-     * @param defaultLogLevel Default log level.
-     * @return The log level.
-     */
-    int parseLogLevel(String logLevel, int defaultLogLevel) {
-        if (logLevel == null || logLevel.length() == 0) {
-            return defaultLogLevel;
-        }
-        String logString = logLevel.trim().toLowerCase();
-        if (logString.equals("verbose")) {
-            return Log.VERBOSE;
-        } else if (logString.equals("debug")) {
-            return Log.DEBUG;
-        } else if (logString.equals("info")) {
-            return Log.INFO;
-        } else if (logString.equals("warn")) {
-            return Log.WARN;
-        } else if (logString.equals("error")) {
-            return Log.ERROR;
-        } else if (logString.equals("none")) {
-            return Log.ASSERT;
-        } else {
-            return defaultLogLevel;
-        }
-    }
-
-    /**
-     * Parses the sender ID.
-     *
-     * @param value The value from config.
-     * @return The sender ID.
-     */
-    private String parseSender(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        if (value.startsWith("sender:")) {
-            return value.substring(SENDER_PREFIX.length());
-        }
-
-        return value;
-    }
-
-    /**
-     * Helper class to parse the Urban Airship plugin config from the Cordova config.xml file.
-     */
-    class PluginConfig {
-        private Map<String, String> configValues = new HashMap<String, String>();
-
-        /**
-         * Constructor for the PluginConfig.
-         *
-         * @param context The application context.
-         */
-        PluginConfig(Context context) {
-            parseConfig(context);
-        }
-
-        /**
-         * Gets a String value from the config.
-         *
-         * @param key The config key.
-         * @param defaultValue Default value if the key does not exist.
-         * @return The value of the config, or default value.
-         */
-        String getString(String key, String defaultValue) {
-            return configValues.containsKey(key) ? configValues.get(key) : defaultValue;
-        }
-
-        /**
-         * Gets a Boolean value from the config.
-         *
-         * @param key The config key.
-         * @param defaultValue Default value if the key does not exist.
-         * @return The value of the config, or default value.
-         */
-        boolean getBoolean(String key, boolean defaultValue) {
-            return configValues.containsKey(key) ?
-                    Boolean.parseBoolean(configValues.get(key)) : defaultValue;
-        }
-
-        /**
-         * Parses the config.xml file.
-         *
-         * @param context The application context.
-         */
-        private void parseConfig(Context context) {
-            int id = context.getResources().getIdentifier("config", "xml", context.getPackageName());
-            if (id == 0) {
-                return;
-            }
-
-            XmlResourceParser xml = context.getResources().getXml(id);
-
-            int eventType = -1;
-            while (eventType != XmlResourceParser.END_DOCUMENT) {
-
-                if (eventType == XmlResourceParser.START_TAG) {
-                    if (xml.getName().equals("preference")) {
-                        String name = xml.getAttributeValue(null, "name").toLowerCase(Locale.US);
-                        String value = xml.getAttributeValue(null, "value");
-
-                        if (name.startsWith(UA_PREFIX) && value != null) {
-                            configValues.put(name, value);
-                            Logger.verbose("Found " + name + " in config.xml with value: " + value);
-                        }
-                    }
-                }
-
-                try {
-                    eventType = xml.next();
-                } catch (Exception e) {
-                    Logger.error("Error parsing config file", e);
-                }
-            }
-        }
-
     }
 }

--- a/src/android/CustomLandingPageActivity.java
+++ b/src/android/CustomLandingPageActivity.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova;
 

--- a/src/android/CustomMessageActivity.java
+++ b/src/android/CustomMessageActivity.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova;
 

--- a/src/android/CustomMessageCenterActivity.java
+++ b/src/android/CustomMessageCenterActivity.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova;
 

--- a/src/android/PluginConfig.java
+++ b/src/android/PluginConfig.java
@@ -1,0 +1,429 @@
+/* Copyright 2018 Urban Airship and Contributors */
+
+package com.urbanairship.cordova;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.XmlResourceParser;
+import android.graphics.Color;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.urbanairship.AirshipConfigOptions;
+import com.urbanairship.Logger;
+import com.urbanairship.util.UAStringUtil;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Manages the plugin config.
+ */
+public class PluginConfig {
+
+    private static final String PREFERENCE_NAME = "com.urbanairship.urbanairship-cordova";
+
+    private static final String SENDER_PREFIX = "sender:";
+
+    private static final String UA_PREFIX = "com.urbanairship";
+    private static final String PRODUCTION_KEY = "com.urbanairship.production_app_key";
+    private static final String PRODUCTION_SECRET = "com.urbanairship.production_app_secret";
+    private static final String DEVELOPMENT_KEY = "com.urbanairship.development_app_key";
+    private static final String DEVELOPMENT_SECRET = "com.urbanairship.development_app_secret";
+    private static final String PRODUCTION_LOG_LEVEL = "com.urbanairship.production_log_level";
+    private static final String DEVELOPMENT_LOG_LEVEL = "com.urbanairship.development_log_level";
+    private static final String IN_PRODUCTION = "com.urbanairship.in_production";
+    private static final String GCM_SENDER = "com.urbanairship.gcm_sender";
+    private static final String ENABLE_PUSH_ONLAUNCH = "com.urbanairship.enable_push_onlaunch";
+    private static final String NOTIFICATION_ICON = "com.urbanairship.notification_icon";
+    private static final String NOTIFICATION_LARGE_ICON = "com.urbanairship.notification_large_icon";
+    private static final String NOTIFICATION_ACCENT_COLOR = "com.urbanairship.notification_accent_color";
+    private static final String NOTIFICATION_SOUND = "com.urbanairship.notification_sound";
+    private static final String AUTO_LAUNCH_MESSAGE_CENTER = "com.urbanairship.auto_launch_message_center";
+    private static final String ENABLE_ANALYTICS = "com.urbanairship.enable_analytics";
+
+    private static PluginConfig instance;
+    private final SharedPreferences sharedPreferences;
+    private final Context context;
+    private AirshipConfigOptions configOptions;
+    private Map<String, String> defaultConfigValues = new HashMap<String, String>();
+
+    private PluginConfig(Context context) {
+        this.context = context.getApplicationContext();
+        this.sharedPreferences = context.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE);
+    }
+
+    /**
+     * Gets the shared instance.
+     *
+     * @param context The context.
+     * @return The shared instance.
+     */
+    public synchronized static PluginConfig shared(Context context) {
+        if (instance == null) {
+            instance = new PluginConfig(context);
+            instance.parseConfig(context);
+        }
+
+        return instance;
+    }
+
+    /**
+     * Gets the airship config for this instance.
+     *
+     * @return The airship config if available, or null if the plugin is not configured.
+     */
+    public AirshipConfigOptions getAirshipConfig() {
+        if (configOptions != null) {
+            return configOptions;
+        }
+
+        if (!containsKey(DEVELOPMENT_KEY) && !containsKey(DEVELOPMENT_SECRET) && !containsKey(PRODUCTION_KEY) && !containsKey(PRODUCTION_SECRET)) {
+            return null;
+        }
+
+        AirshipConfigOptions.Builder builder = new AirshipConfigOptions.Builder()
+                .setDevelopmentAppKey(getString(DEVELOPMENT_KEY, ""))
+                .setDevelopmentAppSecret(getString(DEVELOPMENT_SECRET, ""))
+                .setProductionAppKey(getString(PRODUCTION_KEY, ""))
+                .setProductionAppSecret(getString(PRODUCTION_SECRET, ""))
+                .setFcmSenderId(parseSender(getString(GCM_SENDER, null)))
+                .setAnalyticsEnabled(getBoolean(ENABLE_ANALYTICS, true))
+                .setDevelopmentLogLevel(parseLogLevel(getString(DEVELOPMENT_LOG_LEVEL, ""), Log.DEBUG))
+                .setProductionLogLevel(parseLogLevel(getString(PRODUCTION_LOG_LEVEL, ""), Log.ERROR))
+                .setNotificationIcon(getResource(NOTIFICATION_ICON, "drawable"))
+                .setNotificationAccentColor(getColor(NOTIFICATION_ACCENT_COLOR, 0));
+
+        if (containsKey(IN_PRODUCTION)) {
+            builder.setInProduction(getBoolean(IN_PRODUCTION, false));
+        } else {
+            builder.detectProvisioningMode(context);
+        }
+
+        try {
+            configOptions = builder.build();
+            return configOptions;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the enable push on launch option.
+     *
+     * @return {@code true} to enable push on launch, otherwise {@code false}.
+     */
+    public boolean getEnablePushOnLaunch() {
+        return getBoolean(ENABLE_PUSH_ONLAUNCH, false);
+    }
+
+    /**
+     * Gets the auto launch message center option.
+     *
+     * @return {@code true} to auto launch message center from a push, otherwise {@code false}.
+     */
+    public boolean getAutoLaunchMessageCenter() {
+        return getBoolean(AUTO_LAUNCH_MESSAGE_CENTER, true);
+    }
+
+    /**
+     * Gets the notification sound.
+     *
+     * @return The notification sound.
+     */
+    @Nullable
+    public Uri getNotificationSound() {
+        int resource = getResource(NOTIFICATION_SOUND, "raw");
+        if (resource != 0) {
+            return Uri.parse("android.resource://" + context.getPackageName() + "/" + resource);
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets the notification large icon.
+     *
+     * @return The notification large icon.
+     */
+    public int getNotificationLargeIcon() {
+        return getResource(NOTIFICATION_LARGE_ICON, "drawable");
+    }
+
+
+    /**
+     * Edits the config.
+     *
+     * @return A config editor.
+     */
+    public ConfigEditor editConfig() {
+        return new ConfigEditor(sharedPreferences.edit());
+    }
+
+    /**
+     * Convert the log level string to an int.
+     *
+     * @param logLevel        The log level as a string.
+     * @param defaultLogLevel Default log level.
+     * @return The log level.
+     */
+    public static int parseLogLevel(String logLevel, int defaultLogLevel) {
+        if (logLevel == null || logLevel.length() == 0) {
+            return defaultLogLevel;
+        }
+        String logString = logLevel.trim().toLowerCase();
+        if (logString.equals("verbose")) {
+            return Log.VERBOSE;
+        } else if (logString.equals("debug")) {
+            return Log.DEBUG;
+        } else if (logString.equals("info")) {
+            return Log.INFO;
+        } else if (logString.equals("warn")) {
+            return Log.WARN;
+        } else if (logString.equals("error")) {
+            return Log.ERROR;
+        } else if (logString.equals("none")) {
+            return Log.ASSERT;
+        } else {
+            return defaultLogLevel;
+        }
+    }
+
+    /**
+     * Parses the sender ID.
+     *
+     * @param value The value from config.
+     * @return The sender ID.
+     */
+    private String parseSender(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value.startsWith("sender:")) {
+            return value.substring(SENDER_PREFIX.length());
+        }
+
+        return value;
+    }
+
+    /**
+     * Gets a String value from the config.
+     *
+     * @param key          The config key.
+     * @param defaultValue Default value if the key does not exist.
+     * @return The value of the config, or default value.
+     */
+    private String getString(String key, String defaultValue) {
+        String value = getValue(key);
+        if (value == null) {
+            return defaultValue;
+        }
+
+        return value;
+    }
+
+    /**
+     * Gets a Boolean value from the config.
+     *
+     * @param key          The config key.
+     * @param defaultValue Default value if the key does not exist.
+     * @return The value of the config, or default value.
+     */
+    private boolean getBoolean(String key, boolean defaultValue) {
+        String value = getValue(key);
+        if (value == null) {
+            return defaultValue;
+        }
+
+        return Boolean.parseBoolean(value);
+    }
+
+    /**
+     * Gets a color value from the config.
+     *
+     * @param key The config key.
+     * @return The parsed color, or defaultColor.
+     */
+    private int getColor(String key, int defaultColor) {
+        String color = getValue(key);
+        if (!UAStringUtil.isEmpty(color)) {
+            try {
+                return Color.parseColor(color);
+            } catch (IllegalArgumentException e) {
+                Logger.error("Unable to parse color: " + color, e);
+            }
+        }
+        return defaultColor;
+    }
+
+    private int getResource(String key, String resourceFolder) {
+        String resourceName = getString(key, null);
+        if (!UAStringUtil.isEmpty(resourceName)) {
+            int id = context.getResources().getIdentifier(resourceName, resourceFolder, context.getPackageName());
+            if (id != 0) {
+                return id;
+            } else {
+                Logger.error("Unable to find resource with name: " + resourceName);
+            }
+        }
+        return 0;
+    }
+
+    private boolean containsKey(String key) {
+        return getValue(key) != null;
+    }
+
+    private String getValue(String key) {
+        return sharedPreferences.getString(key, defaultConfigValues.get(key));
+    }
+
+    /**
+     * Parses the config.xml file.
+     *
+     * @param context The application context.
+     */
+    private void parseConfig(Context context) {
+        int id = context.getResources().getIdentifier("config", "xml", context.getPackageName());
+        if (id == 0) {
+            return;
+        }
+
+        XmlResourceParser xml = context.getResources().getXml(id);
+
+        int eventType = -1;
+        while (eventType != XmlResourceParser.END_DOCUMENT) {
+
+            if (eventType == XmlResourceParser.START_TAG) {
+                if (xml.getName().equals("preference")) {
+                    String name = xml.getAttributeValue(null, "name").toLowerCase(Locale.US);
+                    String value = xml.getAttributeValue(null, "value");
+
+                    if (name.startsWith(UA_PREFIX) && value != null) {
+                        defaultConfigValues.put(name, value);
+                        Logger.verbose("Found " + name + " in config.xml with value: " + value);
+                    }
+                }
+            }
+
+            try {
+                eventType = xml.next();
+            } catch (Exception e) {
+                Logger.error("Error parsing config file", e);
+            }
+        }
+    }
+
+    /**
+     * Config editor.
+     */
+    public class ConfigEditor {
+        private final SharedPreferences.Editor editor;
+
+        private ConfigEditor(SharedPreferences.Editor editor) {
+            this.editor = editor;
+        }
+
+        /**
+         * Sets the production app key and secret.
+         *
+         * @param appKey    The app key.
+         * @param appSecret The app secret.
+         * @return The config editor.
+         */
+        public ConfigEditor setProductionConfig(@NonNull String appKey, @NonNull String appSecret) {
+            editor.putString(PRODUCTION_KEY, appKey)
+                    .putString(PRODUCTION_SECRET, appSecret);
+            return this;
+        }
+
+        /**
+         * Sets the production log level.
+         *
+         * @param logLevel The log level.
+         * @return The config editor.
+         */
+        public ConfigEditor setProductionLogLevel(@Nullable String logLevel) {
+            editor.putString(PRODUCTION_LOG_LEVEL, logLevel);
+            return this;
+        }
+
+        /**
+         * Sets the development app key and secret.
+         *
+         * @param appKey    The app key.
+         * @param appSecret The app secret.
+         * @return The config editor.
+         */
+        public ConfigEditor setDevelopmentConfig(@NonNull String appKey, @NonNull String appSecret) {
+            editor.putString(DEVELOPMENT_KEY, appKey)
+                    .putString(DEVELOPMENT_SECRET, appSecret);
+            return this;
+        }
+
+        /**
+         * Sets the development log level.
+         *
+         * @param logLevel The log level.
+         * @return The config editor.
+         */
+        public ConfigEditor setDevelopmentLogLevel(@Nullable String logLevel) {
+            editor.putString(DEVELOPMENT_LOG_LEVEL, logLevel);
+            return this;
+        }
+
+        /**
+         * Sets the notification icon.
+         *
+         * @param icon The icon name.
+         * @return The config editor.
+         */
+        public ConfigEditor setNotificationIcon(String icon) {
+            editor.putString(NOTIFICATION_ICON, icon);
+            return this;
+        }
+
+        /**
+         * Sets the notification large icon.
+         *
+         * @param largeIcon The icon name.
+         * @return The config editor.
+         */
+        public ConfigEditor setNotificationLargeIcon(String largeIcon) {
+            editor.putString(NOTIFICATION_LARGE_ICON, largeIcon);
+            return this;
+        }
+
+        /**
+         * Sets the notification accent color.
+         *
+         * @param accentColor The accent color.
+         * @return The config editor.
+         */
+        public ConfigEditor setNotificationAccentColor(String accentColor) {
+            editor.putString(NOTIFICATION_ACCENT_COLOR, accentColor);
+            return this;
+        }
+
+        /**
+         * Sets auto launch message center option.
+         *
+         * @param autoLaunchMessageCenter {@code true} to enable auto launching the message enter, otherwise {@code false}.
+         * @return The config editor.
+         */
+        public ConfigEditor setAutoLaunchMessageCenter(boolean autoLaunchMessageCenter) {
+            editor.putString(AUTO_LAUNCH_MESSAGE_CENTER, Boolean.toString(autoLaunchMessageCenter));
+            return this;
+        }
+
+        /**
+         * Applies the changes.
+         */
+        void apply() {
+            editor.apply();
+        }
+    }
+}

--- a/src/android/PluginManager.java
+++ b/src/android/PluginManager.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova;
 
@@ -47,7 +24,7 @@ import java.util.List;
 /**
  * Handles state and events for the Cordova Plugin.
  */
-public class UAirshipPluginManager {
+public class PluginManager {
 
     /**
      * Interface when a new event is received.
@@ -56,7 +33,7 @@ public class UAirshipPluginManager {
         void onEvent(Event event);
     }
 
-    private static final UAirshipPluginManager shared = new UAirshipPluginManager();
+    private static final PluginManager shared = new PluginManager();
 
     private static final String NOTIFICATION_OPT_IN_STATUS_EVENT_PREFERENCES_KEY = "com.urbanairship.notification_opt_in_status_preferences";
     private static final String UA_PLUGIN_SHARED_PREFERENCES_FILE = "com.urbanairship.ua_plugin_shared_preferences";
@@ -69,17 +46,13 @@ public class UAirshipPluginManager {
 
     private List<Event> pendingEvents = new ArrayList<Event>();
 
-    private UAirshipPluginManager() {
-
-    }
-
 
     /**
      * Singleton access.
      *
      * @return The manager instance.
      */
-    public static UAirshipPluginManager shared() {
+    public static PluginManager shared() {
         return shared;
     }
 
@@ -134,7 +107,7 @@ public class UAirshipPluginManager {
 
             SharedPreferences.Editor editor = preferences.edit();
             editor.putBoolean(NOTIFICATION_OPT_IN_STATUS_EVENT_PREFERENCES_KEY, optIn);
-            editor.commit();
+            editor.apply();
 
             notifyListener(new NotificationOptInEvent(optIn));
         }

--- a/src/android/events/DeepLinkEvent.java
+++ b/src/android/events/DeepLinkEvent.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova.events;
 

--- a/src/android/events/Event.java
+++ b/src/android/events/Event.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova.events;
 

--- a/src/android/events/InboxEvent.java
+++ b/src/android/events/InboxEvent.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova.events;
 

--- a/src/android/events/NotificationOpenedEvent.java
+++ b/src/android/events/NotificationOpenedEvent.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova.events;
 
@@ -30,13 +7,9 @@ import android.support.annotation.Nullable;
 
 import com.urbanairship.AirshipReceiver;
 import com.urbanairship.Logger;
-import com.urbanairship.push.PushMessage;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Notification opened event.

--- a/src/android/events/NotificationOptInEvent.java
+++ b/src/android/events/NotificationOptInEvent.java
@@ -1,17 +1,13 @@
-/* Copyright 2017 Urban Airship and Contributors */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova.events;
 
 import android.support.annotation.NonNull;
 
 import com.urbanairship.Logger;
-import com.urbanairship.push.PushMessage;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.HashMap;
-import java.util.Map;
 
 
 /**

--- a/src/android/events/PushEvent.java
+++ b/src/android/events/PushEvent.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova.events;
 

--- a/src/android/events/RegistrationEvent.java
+++ b/src/android/events/RegistrationEvent.java
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 package com.urbanairship.cordova.events;
 

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -1,27 +1,4 @@
-/*
- Copyright 2009-2017 Urban Airship Inc. All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- EVENT SHALL URBAN AIRSHIP INC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+/* Copyright 2018 Urban Airship and Contributors */
 
 var cardova = require("cordova"),
     exec = require("cordova/exec"),
@@ -205,6 +182,34 @@ module.exports = {
    * Re-attaches document event listeners in this webview
    */
   reattach: bindDocumentEvent,
+
+  /**
+   * Initailizes Urban Airship.
+   *
+   * The plugin will automatically call takeOff during the next app init in
+   * order to properly handle incoming push. If takeOff is called multiple times
+   * in a session, or if the config is different than the previous sesssion, the
+   * new config will not be used until the next app start.
+   *
+   * @param {object}  config The Urban Airship Config.
+   * @param {object}  config.development The Urban Airship development config.
+   * @param {string}  config.development.appKey The development appKey.
+   * @param {string}  config.development.appSecret The development appSecret.
+   * @param {string}  [config.development.logLevel] The development log level.
+   * @param {object}  config.production The Urban Airship production config.
+   * @param {string}  config.production.appKey The production appKey.
+   * @param {string}  config.production.appSecret The production appSecret.
+   * @param {string}  [config.production.logLevel] The production log level.
+   * @param {object}  [config.android] The Urban Airship Android Config.
+   * @param {string}  [config.android.notificationIcon] The name of the drawable resource to use as the notification icon.
+   * @param {string}  [config.android.notificationLargeIcon] The name of the drawable resource to use as the notification large icon.
+   * @param {string}  [config.android.notificationAccentColor] The notification accent color. Format is #AARRGGBB.
+   * @param {boolean} [config.autoLaunchMessageCenter] True to enable auto launching the message center when the corresponding push is opened. False to disable.
+   */
+  takeOff: function(config, success, failure) {
+    argscheck.checkArgs("*FF", "UAirship.takeOff", arguments);
+    callNative(success, failure, "takeOff", [namedUser]);
+  },
 
   /**
    * Enables or disables user notifications.


### PR DESCRIPTION
Enables calling takeOff from JS. PR only covers Android, iOS will get its own PR.

Config is applied with the following rules:
- Values always default to config.xml values
- Values supplied in JS takeOff will override config.xml values
- If takeOff is already called, new values will be applied during the next app init
