### PR TITLE
[MOBILE-237] Cordova: Add setter for foreground presentation options

### DIFF
--- a/src/ios/UACordovaPluginManager.h
+++ b/src/ios/UACordovaPluginManager.h
@@ -68,4 +68,11 @@
  * @param appSecret The appSecret.
  */
 - (void)setProductionAppKey:(NSString *)appKey appSecret:(NSString *)appSecret;
+
+/**
+ * Sets the presentation options.
+ * @param options The presentation options.
+ */
+- (void)setPresentationOptions:(NSUInteger)options;
+
 @end

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -144,6 +144,12 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     [[NSUserDefaults standardUserDefaults] setValue:appSecret forKey:DevelopmentAppSecretConfigKey];
 }
 
+- (void)setPresentationOptions:(NSUInteger)options {
+    [[NSUserDefaults standardUserDefaults] setValue:@(options & UNNotificationPresentationOptionAlert) forKey:NotificationPresentationAlertKey];
+    [[NSUserDefaults standardUserDefaults] setValue:@(options & UNNotificationPresentationOptionBadge) forKey:NotificationPresentationBadgeKey];
+    [[NSUserDefaults standardUserDefaults] setValue:@(options & UNNotificationPresentationOptionSound) forKey:NotificationPresentationSoundKey];
+}
+
 -(NSInteger)parseLogLevel:(id)logLevel defaultLogLevel:(UALogLevel)defaultValue  {
     if (![logLevel isKindOfClass:[NSString class]] || ![logLevel length]) {
         return defaultValue;
@@ -203,7 +209,6 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
                      completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
     UA_LDEBUG(@"Received a background notification %@", notificationContent);
-
     id event = [self pushEventFromNotification:notificationContent];
 
     [self fireEvent:EventPushReceived data:event];

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -209,6 +209,15 @@
 - (void)setNotificationTypes:(CDVInvokedUrlCommand *)command;
 
 /**
+ * Sets notification presentation options.
+ *
+ * Expected arguments: Number - bitmask of the notification options
+ *
+ * @param command The cordova command.
+ */
+- (void)setPresentationOptions:(CDVInvokedUrlCommand *)command;
+
+/**
  * Enables or disables analytics.
  *
  * Disabling analytics will delete any locally stored events

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -188,6 +188,16 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     }];
 }
 
+- (void)setPresentationOptions:(CDVInvokedUrlCommand *)command {
+    [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
+        UNNotificationPresentationOptions options = [[args objectAtIndex:0] intValue];
+
+        UA_LDEBUG(@"Setting presentation options types: %ld", (long)options);
+        [self.pluginManager setPresentationOptions:(NSUInteger)options];
+        completionHandler(CDVCommandStatus_OK, nil);
+    }];
+}
+
 - (void)setUserNotificationsEnabled:(CDVInvokedUrlCommand *)command {
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
         BOOL enabled = [[args objectAtIndex:0] boolValue];

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -791,7 +791,7 @@ module.exports = {
 
   /**
    * Sets the iOS notification types. Specify the combination of
-   * badges, sound and alerts are desired.
+   * badges, sound and alerts that are desired.
    *
    * @param {notificationType} types specified notification types.
    * @param {function} [success] Success callback.
@@ -802,6 +802,20 @@ module.exports = {
     argscheck.checkArgs('nFF', 'UAirship.setNotificationTypes', arguments)
     callNative(success, failure, "setNotificationTypes", [types])
   },
+
+  /**
+   * Sets the iOS presentation options. Specify the combination of
+   * badges, sound and alerts that are desired.
+   *
+   * @param {presentationOptions} types specified presentation options.
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   */
+   setPresentationOptions: function(options, success, failure) {
+     argscheck.checkArgs('nFF', 'UAirship.setPresentationOptions', arguments)
+     callNative(success, failure, "setPresentationOptions", [options])
+   },
 
   /**
    * Enum for notification types.

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -829,6 +829,18 @@ module.exports = {
     alert: 4
   },
 
+  /**
+   * Enum for presentation options.
+   * @readonly
+   * @enum {number}
+   */
+  presentationOptions: {
+    none: 0,
+    badge: 1,
+    sound: 2,
+    alert: 4
+  },
+
   // Android only
 
   /**


### PR DESCRIPTION
### What do these changes do?
This adds a setter for presentation options that's accessible from the JS layer/

### Why are these changes necessary?
These changes are necessary for users to dynamically set the presentation options from the JS layer and eventually move away from setting presentation options in the config entirely. 

### How did you verify these changes?
Added the new presentation options setter call to the quietTimeEnabled button (temporarily) and traced execution through the expected plugin and plugin manager calls.

#### Verification Screenshots:
![screen shot 2018-07-25 at 4 59 46 pm](https://user-images.githubusercontent.com/2199816/43233929-d997f488-902d-11e8-84d1-648f76442d74.png)
![screen shot 2018-07-25 at 5 12 26 pm](https://user-images.githubusercontent.com/2199816/43233950-f09c2ce4-902d-11e8-8a2c-0b5cd96b44ad.png)
