### PR TITLE
Fixing issue on init firebese in Android

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -27,6 +27,6 @@ dependencies {
     implementation 'com.urbanairship.android:urbanairship-fcm:9.4.1'
 }
 
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.push({
     apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-}
+})


### PR DESCRIPTION
### What do these changes do?

Refactor 'ext.postBuildExtras' to use 'cdvPluginPostBuildExtras.push'

### Why are these changes necessary?

When you build a cordova project with this urban plugin, GoogleServicesPlugin is not executed on android build.

This cause that firebase properties, from 'google-services.json', are not parsed into 'strings.xml'. And when you launch the application, urban fails on register into Firebase.

### How did you verify these changes?

Run an android project without the fix. On launch android app we will see in the logcat next message:
`UALib: Unable to register with FCM: Defatult FirebaseApp is not initialized in the process <package name>. Make sure to call FirebaseApp.initializedApp(Context) first.`

This is showed by the 'autopilot' because it can't find firebase properties and firebase register fails.

Next, run the app with the fix. You will see on build gradle that the function `:app:processDebugGoogleServices` is executed and the error is disappeared in the logcat.

#### Verification Screenshots:

Before fix:
![build before fix](https://user-images.githubusercontent.com/7089938/45621874-5175f580-ba82-11e8-8efc-547be09631a5.png)
![logcat before fix](https://user-images.githubusercontent.com/7089938/45621880-5470e600-ba82-11e8-917b-e96df21e18c9.png)

After fix:
![build after fix](https://user-images.githubusercontent.com/7089938/45621885-59ce3080-ba82-11e8-84d9-7cd563394bbc.png)

### Anything else a reviewer should know?
It seems cordova use this method to apply plugins. It will be execute in this line from `build.gradle` app:
```
for (def func : cdvPluginPostBuildExtras) {
    func()
}
```
The workaround we are currently using is to apply this plugin in our project's root `build-extras.gradle`:
```
// This can be defined within build-extras.gradle as:
//     ext.postBuildExtras = { ... code here ... }
if (hasProperty('postBuildExtras')) {
    postBuildExtras()
}
```
But is somewhat a hack and we suppose it would be better to fix it in the plugin.