### PR TITLE
Specify inferred types for backwards compatibility, fix reference to Context

### DIFF
--- a/src/android/ConfigUtils.java
+++ b/src/android/ConfigUtils.java
@@ -72,7 +72,7 @@ class ConfigUtils {
      * @param context The application context.
      */
     public static Map<String, String> parseConfigXml(Context context) {
-        Map<String, String> config = new HashMap<>();
+        Map<String, String> config = new HashMap<String, String>();
         int id = context.getResources().getIdentifier("config", "xml", context.getPackageName());
         if (id == 0) {
             return config;

--- a/src/android/PluginManager.java
+++ b/src/android/PluginManager.java
@@ -68,7 +68,7 @@ public class PluginManager {
     private NotificationOpenedEvent notificationOpenedEvent;
     private DeepLinkEvent deepLinkEvent = null;
     private Listener listener = null;
-    private List<Event> pendingEvents = new ArrayList<>();
+    private List<Event> pendingEvents = new ArrayList<Event>();
 
     private final SharedPreferences sharedPreferences;
     private final Map<String, String> defaultConfigValues;

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -87,7 +87,7 @@ public class UAirshipPlugin extends CordovaPlugin {
         super.initialize(cordova, webView);
         Logger.info("Initializing Urban Airship cordova plugin.");
 
-        context = cordova.getContext().getApplicationContext();
+        context = cordova.getActivity().getApplicationContext();
         pluginManager = PluginManager.shared(context);
     }
 


### PR DESCRIPTION
# Please fill out this template when submitting a pull request.
All lines beginning with an ℹ symbol indicate information that's important for you to provide to ensure your pull request is reviewed as quickly and efficiently as possible.

### What do these changes do?
Adds explicit types to any `<>` declarations to allow older Cordova Android (<= 6.4.0) to build
Changes `cordova.getContext()` to `cordova.getActivity().getApplicationContext()`.

### Why are these changes necessary?
To allow builds against `cordova-android@<=6.4.0`

### How did you verify these changes?
Forked the repo, made the changes, built the app.
