### PR TITLE
[MOBILE-362] Prevent early takeOff

### DIFF
--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -33,6 +33,11 @@ public class CordovaAutopilot extends Autopilot {
     }
 
     @Override
+    public boolean allowEarlyTakeOff(@NonNull Context context) {
+        return false;
+    }
+
+    @Override
     public void onAirshipReady(UAirship airship) {
         Context context = UAirship.getApplicationContext();
         final PluginManager pluginManager = PluginManager.shared(context);

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -86,8 +86,9 @@ public class UAirshipPlugin extends CordovaPlugin {
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
         Logger.info("Initializing Urban Airship cordova plugin.");
-
         context = cordova.getActivity().getApplicationContext();
+
+        Autopilot.automaticTakeOff(context);
         pluginManager = PluginManager.shared(context);
     }
 


### PR DESCRIPTION
### What do these changes do?
Prevents early takeOff (before application.onCreate)

### Why are these changes necessary?
Makes our plugin compatible with APK wrappers.

### How did you verify these changes?
Ran the sample.
