### PR TITLE
[MOBILE-406] active notification API

### DIFF
--- a/src/android/CordovaNotificationFactory.java
+++ b/src/android/CordovaNotificationFactory.java
@@ -5,7 +5,9 @@ package com.urbanairship.cordova;
 import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.v4.app.NotificationCompat;
 
+import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.notifications.DefaultNotificationFactory;
 
 
@@ -21,6 +23,12 @@ public class CordovaNotificationFactory extends DefaultNotificationFactory {
         super(context);
         appIcon = context.getApplicationInfo().icon;
         pluginManager = PluginManager.shared(context);
+    }
+
+    @Override
+    public NotificationCompat.Builder extendBuilder(@NonNull NotificationCompat.Builder builder, @NonNull PushMessage message, int notificationId) {
+        builder.getExtras().putBundle("push_message", message.getPushBundle());
+        return builder;
     }
 
     @Override

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -12,6 +12,8 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
+import android.support.annotation.NonNull;
+import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.ContextCompat;
 
@@ -31,6 +33,7 @@ import com.urbanairship.google.PlayServicesUtils;
 import com.urbanairship.json.JsonValue;
 import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.TagGroupsEditor;
+import com.urbanairship.push.notifications.DefaultNotificationFactory;
 import com.urbanairship.richpush.RichPushInbox;
 import com.urbanairship.richpush.RichPushMessage;
 import com.urbanairship.util.HelperActivity;
@@ -221,6 +224,16 @@ public class UAirshipPlugin extends CordovaPlugin {
         if (!pluginManager.isAirshipAvailable()) {
             callbackContext.error("Airship config is invalid. Unable to takeOff.");
         }
+
+        DefaultNotificationFactory notificationFactory = new DefaultNotificationFactory(UAirship.getApplicationContext()) {
+            @Override
+            public NotificationCompat.Builder extendBuilder(@NonNull NotificationCompat.Builder builder, @NonNull PushMessage message, int notificationId) {
+                builder.getExtras().putBundle("push_message", message.getPushBundle());
+                return builder;
+            }
+        };
+
+        UAirship.shared().getPushManager().setNotificationFactory(notificationFactory);
 
         callbackContext.success();
     }
@@ -1220,6 +1233,7 @@ public class UAirshipPlugin extends CordovaPlugin {
 
                 PushMessage pushMessage;
                 Bundle extras = statusBarNotification.getNotification().extras;
+
                 if (extras != null && extras.containsKey("push_message")) {
                     pushMessage = new PushMessage(extras.getBundle("push_message"));
                 } else {

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -12,8 +12,6 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
-import android.support.annotation.NonNull;
-import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.ContextCompat;
 
@@ -33,7 +31,6 @@ import com.urbanairship.google.PlayServicesUtils;
 import com.urbanairship.json.JsonValue;
 import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.TagGroupsEditor;
-import com.urbanairship.push.notifications.DefaultNotificationFactory;
 import com.urbanairship.richpush.RichPushInbox;
 import com.urbanairship.richpush.RichPushMessage;
 import com.urbanairship.util.HelperActivity;
@@ -224,16 +221,6 @@ public class UAirshipPlugin extends CordovaPlugin {
         if (!pluginManager.isAirshipAvailable()) {
             callbackContext.error("Airship config is invalid. Unable to takeOff.");
         }
-
-        DefaultNotificationFactory notificationFactory = new DefaultNotificationFactory(UAirship.getApplicationContext()) {
-            @Override
-            public NotificationCompat.Builder extendBuilder(@NonNull NotificationCompat.Builder builder, @NonNull PushMessage message, int notificationId) {
-                builder.getExtras().putBundle("push_message", message.getPushBundle());
-                return builder;
-            }
-        };
-
-        UAirship.shared().getPushManager().setNotificationFactory(notificationFactory);
 
         callbackContext.success();
     }
@@ -1233,7 +1220,6 @@ public class UAirshipPlugin extends CordovaPlugin {
 
                 PushMessage pushMessage;
                 Bundle extras = statusBarNotification.getNotification().extras;
-
                 if (extras != null && extras.containsKey("push_message")) {
                     pushMessage = new PushMessage(extras.getBundle("push_message"));
                 } else {

--- a/src/android/events/PushEvent.java
+++ b/src/android/events/PushEvent.java
@@ -4,6 +4,7 @@ package com.urbanairship.cordova.events;
 
 import com.urbanairship.Logger;
 import com.urbanairship.push.PushMessage;
+import com.urbanairship.util.UAStringUtil;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -20,9 +21,16 @@ public class PushEvent implements Event {
 
     private final PushMessage message;
     private final Integer notificationId;
+    private String notificationTag;
 
     public PushEvent(Integer notificationId, PushMessage message) {
         this.notificationId = notificationId;
+        this.message = message;
+    }
+
+    public PushEvent(Integer notificationId, PushMessage message, String tag) {
+        this.notificationId = notificationId;
+        this.notificationTag = tag;
         this.message = message;
     }
 
@@ -55,10 +63,21 @@ public class PushEvent implements Event {
             data.putOpt("message", message.getAlert());
             data.putOpt("extras", new JSONObject(extras));
             data.putOpt("notification_id", notificationId);
+            data.putOpt("notificationId", getNotificationdId(notificationId, notificationTag));
         } catch (JSONException e) {
             Logger.error("Error constructing notification object", e);
         }
 
         return data;
     }
+
+    static String getNotificationdId(int notificationId, String notificationTag) {
+        String id = String.valueOf(notificationId);
+        if (!UAStringUtil.isEmpty(notificationTag)) {
+            id += ":" + notificationTag;
+        }
+
+        return id;
+    }
+
 }

--- a/src/ios/UACordovaPluginManager.h
+++ b/src/ios/UACordovaPluginManager.h
@@ -1,6 +1,7 @@
 /* Copyright 2018 Urban Airship and Contributors */
 
 #import <Foundation/Foundation.h>
+#import "AirshipLib.h"
 
 /**
  * Manager delegate.
@@ -74,5 +75,13 @@
  * @param options The presentation options.
  */
 - (void)setPresentationOptions:(NSUInteger)options;
+
+/**
+ * Generates a push event dictionary from a notification content object.
+ *
+ * @param notificationContent The notification content.
+ * @return A push event dictionary.
+ */
+- (NSDictionary *)pushEventFromNotification:(UANotificationContent *)notificationContent;
 
 @end

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -386,4 +386,27 @@
  */
 - (void)isAppNotificationsEnabled:(CDVInvokedUrlCommand *)command;
 
+/**
+ * Gets the currently active notifications.
+ *
+ * @param command The cordova command.
+ */
+- (void)getActiveNotifications:(CDVInvokedUrlCommand *)command;
+
+/**
+ * Clears notifications by identifier.
+ *
+ * Expected arguemts: String - notification identifier.
+ *
+ * @param command The cordova command.
+ */
+- (void)clearNotification:(CDVInvokedUrlCommand *)command;
+
+/**
+ * Clears all notifications.
+ *
+ * @param command The cordova command.
+ */
+- (void)clearNotifications:(CDVInvokedUrlCommand *)command;
+
 @end

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -768,6 +768,8 @@ module.exports = {
   /**
    * Gets currently active notifications.
    *
+   * Note: On Android this functionality is only supported on Android M or higher.
+   *
    * @param {function(messages)} [success] Success callback.
    * @param {function(message)} [failure] Failure callback.
    */

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -151,7 +151,8 @@ module.exports = {
    * @param {string} subtitle The push subtitle.
    * @param {object} extras Any push extras.
    * @param {object} aps The raw aps dictionary (iOS only)
-   * @param {number} [notification_id] The Android notification ID.
+   * @param {number} [notification_id] The Android notification ID. Deprecated in favor of notificationId.
+   * @param {string} [notificationId] The notification ID.
    */
 
   /**
@@ -161,7 +162,8 @@ module.exports = {
    * @type {object}
    * @param {string} message The push alert message.
    * @param {object} extras Any push extras.
-   * @param {number} [notification_id] The Android notification ID.
+   * @param {number} [notification_id] The Android notification ID. Deprecated in favor of notificationId.
+   * @param {string} [notificationId] The notification ID.
    * @param {string} [actionID] The ID of the notification action button if available.
    * @param {boolean} isForeground Will always be true if the user taps the main notification. Otherwise its defined by the notification action button.
    */
@@ -739,6 +741,41 @@ module.exports = {
     callNative(success, failure, 'overlayInboxMessage', [messageId])
   },
 
+  /**
+   * Clears a notification by identifier.
+   *
+   * @param {string} identifier The notification identifier.
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   */
+  clearNotification: function(identifier, success, failure) {
+    argscheck.checkArgs('sFF', 'UAirship.clearNotification', arguments)
+    callNative(success, failure, "clearNotification", [identifier])
+  },
+
+  /**
+   * Clears all notifications posted by the application.
+   *
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   */
+  clearNotifications: function(success, failure) {
+    argscheck.checkArgs('FF', 'UAirship.clearNotifications', arguments)
+    callNative(success, failure, "clearNotifications")
+  },
+
+  /**
+   * Gets currently active notifications.
+   *
+   * @param {function(messages)} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   */
+  getActiveNotifications: function(success, failure) {
+    argscheck.checkArgs('fF', 'UAirship.getActiveNotifications', arguments)
+    callNative(success, failure, "getActiveNotifications")
+  },
+
   // iOS only
 
   /**
@@ -845,18 +882,6 @@ module.exports = {
   },
 
   // Android only
-
-  /**
-   * Clears all notifications posted by the application.
-   *
-   * @param {function} [success] Success callback.
-   * @param {function(message)} [failure] Failure callback.
-   * @param {string} failure.message The error message.
-   */
-  clearNotifications: function(success, failure) {
-    argscheck.checkArgs('FF', 'UAirship.clearNotifications', arguments)
-    callNative(success, failure, "clearNotifications")
-  },
 
   /**
    * Checks if notification sound is enabled or not.


### PR DESCRIPTION
This adds the ability to get active (posted) notifications to our cordova plugin, as well as clear notifications, either wholesale or by identifier. The overall structure of the solution is modeled after our react module, which I borrowed a bit of code from where appropriate.

The way we've been doing this in react has been to pass up notification identifiers as strings on Android, and when appropriate affixing the notification tag if it has one. The resulting strings look like "<ID>:<TAG>", and have to be re-parsed into their constituent parts when calling getActiveNotifications. This has the advantage of making a relatively uniform API, since iOS notifications have UUIDs for identifiers. In order to do this I deprecated the notification_id field in the push event and added a notificationId field, which will always be a string regardless of platform. This matches the react API.

Tested manually in all the janky ways one would expect for a cordova project. Things seems to be humming along nicely.