### PR TITLE
[MOBILE-412] Add showInbox event to iOS and Android implementations

### DIFF
--- a/src/android/PluginManager.java
+++ b/src/android/PluginManager.java
@@ -22,6 +22,7 @@ import com.urbanairship.cordova.events.NotificationOpenedEvent;
 import com.urbanairship.cordova.events.NotificationOptInEvent;
 import com.urbanairship.cordova.events.PushEvent;
 import com.urbanairship.cordova.events.RegistrationEvent;
+import com.urbanairship.cordova.events.ShowInboxEvent;
 import com.urbanairship.push.PushMessage;
 import com.urbanairship.util.UAStringUtil;
 
@@ -66,6 +67,7 @@ public class PluginManager {
 
     private NotificationOpenedEvent notificationOpenedEvent;
     private DeepLinkEvent deepLinkEvent = null;
+    private ShowInboxEvent showInboxEvent = null;
     private Listener listener = null;
     private List<Event> pendingEvents = new ArrayList<Event>();
 
@@ -124,6 +126,20 @@ public class PluginManager {
 
             if (!notifyListener(event)) {
                 pendingEvents.add(event);
+            }
+        }
+    }
+
+    /**
+     * Called to open the inbox when auto launch is disabled.
+     *
+     * @param showInboxEvent The show inbox event.
+     */
+    public void sendShowInboxEvent(ShowInboxEvent showInboxEvent) {
+        synchronized (lock) {
+            this.showInboxEvent = showInboxEvent;
+            if (!notifyListener(showInboxEvent)) {
+                pendingEvents.add(showInboxEvent);
             }
         }
     }

--- a/src/android/PluginManager.java
+++ b/src/android/PluginManager.java
@@ -67,7 +67,6 @@ public class PluginManager {
 
     private NotificationOpenedEvent notificationOpenedEvent;
     private DeepLinkEvent deepLinkEvent = null;
-    private ShowInboxEvent showInboxEvent = null;
     private Listener listener = null;
     private List<Event> pendingEvents = new ArrayList<Event>();
 
@@ -137,7 +136,6 @@ public class PluginManager {
      */
     public void sendShowInboxEvent(ShowInboxEvent showInboxEvent) {
         synchronized (lock) {
-            this.showInboxEvent = showInboxEvent;
             if (!notifyListener(showInboxEvent)) {
                 pendingEvents.add(showInboxEvent);
             }

--- a/src/android/events/ShowInboxEvent.java
+++ b/src/android/events/ShowInboxEvent.java
@@ -1,0 +1,51 @@
+/* Copyright 2017 Urban Airship and Contributors */
+
+package com.urbanairship.cordova.events;
+
+import android.support.annotation.Nullable;
+import com.urbanairship.Logger;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+
+
+/**
+ * Show inbox event.
+ */
+public class ShowInboxEvent implements Event {
+
+    private static final String SHOW_INBOX_EVENT = "urbanairship.show_inbox";
+    private static final String MESSAGE_ID = "messageId";
+
+    private final String messageId;
+
+    /**
+     * Default constructor.
+     *
+     * @param messageId The optional message ID.
+     */
+    public ShowInboxEvent(@Nullable String messageId) {
+        this.messageId = messageId;
+    }
+
+    @Override
+    public String getEventName() {
+        return SHOW_INBOX_EVENT;
+    }
+
+    @Override
+    public JSONObject getEventData() {
+        JSONObject data = new JSONObject();
+        
+        try {
+            if (messageId != null) {
+                data.put(MESSAGE_ID, messageId);
+            }
+        } catch (JSONException e) {
+            Logger.error("Error in show inbox event", e);
+        };
+
+        return data;
+    }
+}

--- a/src/android/events/ShowInboxEvent.java
+++ b/src/android/events/ShowInboxEvent.java
@@ -1,4 +1,4 @@
-/* Copyright 2017 Urban Airship and Contributors */
+/* Copyright 2019 Urban Airship and Contributors */
 
 package com.urbanairship.cordova.events;
 

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -31,6 +31,7 @@ NSString *const EventPushReceived = @"urbanairship.push";
 NSString *const EventNotificationOpened = @"urbanairship.notification_opened";
 NSString *const EventNotificationOptInStatus = @"urbanairship.notification_opt_in_status";
 
+NSString *const EventShowInbox = @"urbanairship.show_inbox";
 NSString *const EventInboxUpdated = @"urbanairship.inbox_updated";
 NSString *const EventRegistration = @"urbanairship.registration";
 NSString *const EventDeepLink = @"urbanairship.deep_link";
@@ -193,6 +194,8 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 - (void)showInbox {
     if (self.autoLaunchMessageCenter) {
         [[UAirship messageCenter] display];
+    } else {
+        [self fireEvent:EventShowInbox data:@{}];
     }
 }
 

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -188,6 +188,8 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 - (void)showMessageForID:(NSString *)messageID {
     if (self.autoLaunchMessageCenter) {
         [[UAirship messageCenter] displayMessageForID:messageID];
+    } else {
+        [self fireEvent:EventShowInbox data:@{@"messageId":messageID}];
     }
 }
 

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -142,6 +142,15 @@ module.exports = {
    */
 
   /**
+   * Event fired when the inbox needs to be displayed. This event is only emitted if auto 
+   * launch message center is disabled.
+   *
+   * @event show_inbox
+   * @type {object}
+   * @param {string} [messageId] The optional message ID.
+   */
+
+  /**
    * Event fired when a push is received.
    *
    * @event push


### PR DESCRIPTION
### What do these changes do?
This adds a showInbox event to both iOS and Android that gets emitted if the default auto displaying inbox is disabled. 

### Why are these changes necessary?
To achieve functional parity with other similar plugins.

### How did you verify these changes?
Ran the sample.