### PR TITLE
Address builds that don't get our plugin from npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "7.3.4",
+  "version": "7.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,7 +34,7 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "0.3.0"
+        "underscore-contrib": "~0.3.0"
       }
     },
     "co": {
@@ -49,7 +49,7 @@
       "integrity": "sha1-+zcOntrEhXayenMv5dfyHZ/G5vY=",
       "dev": true,
       "requires": {
-        "keypress": "0.2.1"
+        "keypress": "~0.2.1"
       }
     },
     "combined-stream": {
@@ -58,7 +58,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -85,7 +85,7 @@
       "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "dev": true,
       "requires": {
-        "ms": "2.1.1"
+        "ms": "^2.1.1"
       }
     },
     "delayed-stream": {
@@ -106,9 +106,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.7",
-        "mime-types": "2.1.21"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "formidable": {
@@ -141,7 +141,7 @@
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
       "dev": true,
       "requires": {
-        "xmlcreate": "1.0.2"
+        "xmlcreate": "^1.0.1"
       }
     },
     "jsdoc": {
@@ -151,17 +151,17 @@
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.1",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "js2xmlparser": "3.0.0",
-        "klaw": "2.0.0",
-        "marked": "0.3.12",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
+        "bluebird": "~3.5.0",
+        "catharsis": "~0.8.9",
+        "escape-string-regexp": "~1.0.5",
+        "js2xmlparser": "~3.0.0",
+        "klaw": "~2.0.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "1.8.3"
+        "underscore": "~1.8.3"
       }
     },
     "keypress": {
@@ -176,7 +176,7 @@
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "marked": {
@@ -209,7 +209,7 @@
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.37.0"
+        "mime-db": "~1.37.0"
       }
     },
     "minami": {
@@ -251,9 +251,9 @@
       "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "string_decoder": "1.2.0",
-        "util-deprecate": "1.0.2"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "requizzle": {
@@ -262,7 +262,7 @@
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
-        "underscore": "1.6.0"
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "underscore": {
@@ -291,7 +291,7 @@
       "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-json-comments": {
@@ -306,15 +306,15 @@
       "integrity": "sha512-qaGDf+QUYxgMYdJBWCezHnc3UjrCUwxm5bCfxBhTXI5BbCluVzmVNYzxvCw1jP9PXmwUZeOW2yPpGm9fLbhtFg==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.2",
-        "debug": "4.1.0",
-        "form-data": "2.3.3",
-        "formidable": "1.2.1",
-        "methods": "1.1.2",
-        "mime": "2.4.0",
-        "qs": "6.6.0",
-        "readable-stream": "3.0.6"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.0.0",
+        "form-data": "^2.3.2",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^2.0.3",
+        "qs": "^6.5.1",
+        "readable-stream": "^3.0.3"
       }
     },
     "taffydb": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
   },
   "scripts": {
     "generate-docs": "jsdoc ./www/UrbanAirship.js -t ./node_modules/minami/ -r jsdoc_readme.md",
-    "prepublishOnly": "source scripts/update_ios_static_lib.sh"
+    "prepare": "source scripts/update_ios_static_lib.sh"
   }
 }

--- a/scripts/create_sample.sh
+++ b/scripts/create_sample.sh
@@ -23,8 +23,8 @@ fi
 # keep cordova up to date
 #npm install cordova -g
 
-# Update ios static lib
-source $ROOT_PATH/scripts/update_ios_static_lib.sh
+# install NPM package
+npm install
 
 # create cordova directory
 mkdir -p $CORDOVA_PATH

--- a/scripts/update_ios_static_lib.sh
+++ b/scripts/update_ios_static_lib.sh
@@ -4,6 +4,12 @@
 VERSION=$(xpath plugin.xml '/plugin/platform[@name="ios"]/source-file[@framework="true"]' 2>/dev/null |
 grep -oh '[0-9]\+\.[0-9]\+\.[0-9]\+')
 
+# Don't copy static library if it already exists
+if [[ -f src/ios/Airship/libUAirship-$VERSION.a ]]; then 
+  echo "libUAirship-$VERSION has already been downloaded"
+  exit
+fi
+
 echo "Downloading libUAirship-$VERSION.zip from bintray..."
 curl -s -LO "https://urbanairship.bintray.com/iOS/urbanairship-sdk/$VERSION/libUAirship-$VERSION.zip"
 echo "Unzipping libUAirship into temp directory..."


### PR DESCRIPTION
### What do these changes do?
Fix local `npm install` to also run our `update_ios_static_lib.sh` script so installs from our GitHub source create a complete cordova plugin.

### Why are these changes necessary?
It appears that Outsystems may be getting our plugin from our GitHub repo and installing it manually. The generated package is missing our static library. This change sets up the static library when `npm install` is run in a checkout of our repo.

### How did you verify these changes?
Ran `npm install` locally. Updated our CI scripts to run `npm install` in the checkout of our repo.

### Anything else a reviewer should know?
This change is driven by several issues reported to us: [iOS build failed](https://github.com/urbanairship/urbanairship-cordova/issues/283) and [src/ios/Airship/libUAirship-10.0.3.a not found](https://github.com/urbanairship/urbanairship-cordova/issues/284).