### PR TITLE
Fix: Maintains 1.6 compatibility for older Cordova projects

### DIFF
--- a/src/android/ConfigUtils.java
+++ b/src/android/ConfigUtils.java
@@ -30,7 +30,7 @@ class ConfigUtils {
         if (logLevel == null || logLevel.length() == 0) {
             return defaultLogLevel;
         }
-				String logString = logLevel.trim().toLowerCase();
+        String logString = logLevel.trim().toLowerCase();
 				if (logString.equals("verbose")) {
 					return Log.VERBOSE;
 				} else if (logString.equals("debug")) {

--- a/src/android/ConfigUtils.java
+++ b/src/android/ConfigUtils.java
@@ -16,93 +16,93 @@ import java.util.Map;
  * Config Utils.
  */
 class ConfigUtils {
-    private static final String UA_PREFIX = "com.urbanairship";
-    private static final String SENDER_PREFIX = "sender:";
+  private static final String UA_PREFIX = "com.urbanairship";
+  private static final String SENDER_PREFIX = "sender:";
 
-    /**
-     * Convert the log level string to an int.
-     *
-     * @param logLevel        The log level as a string.
-     * @param defaultLogLevel Default log level.
-     * @return The log level.
-     */
-    public static int parseLogLevel(@Nullable String logLevel, int defaultLogLevel) {
-        if (logLevel == null || logLevel.length() == 0) {
-            return defaultLogLevel;
-        }
-        String logString = logLevel.trim().toLowerCase();
-				if (logString.equals("verbose")) {
-					return Log.VERBOSE;
-				} else if (logString.equals("debug")) {
-					return Log.DEBUG;
-				} else if (logString.equals("info")) {
-					return Log.INFO;
-				} else if (logString.equals("warn")) {
-					return Log.WARN;
-				} else if (logString.equals("error")) {
-					return Log.ERROR;
-				} else if (logString.equals("none")) {
-					return Log.ASSERT;
-				}
-				return defaultLogLevel;
+  /**
+   * Convert the log level string to an int.
+   *
+   * @param logLevel        The log level as a string.
+   * @param defaultLogLevel Default log level.
+   * @return The log level.
+   */
+  public static int parseLogLevel(@Nullable String logLevel, int defaultLogLevel) {
+    if (logLevel == null || logLevel.length() == 0) {
+      return defaultLogLevel;
+    }
+    String logString = logLevel.trim().toLowerCase();
+    if (logString.equals("verbose")) {
+      return Log.VERBOSE;
+    } else if (logString.equals("debug")) {
+      return Log.DEBUG;
+    } else if (logString.equals("info")) {
+      return Log.INFO;
+    } else if (logString.equals("warn")) {
+      return Log.WARN;
+    } else if (logString.equals("error")) {
+      return Log.ERROR;
+    } else if (logString.equals("none")) {
+      return Log.ASSERT;
+    }
+    return defaultLogLevel;
+  }
+
+  /**
+   * Parses the sender ID.
+   *
+   * @param value The value from config.
+   * @return The sender ID.
+   */
+  @Nullable
+  public static String parseSender(@Nullable String value) {
+    if (value == null) {
+      return null;
     }
 
-    /**
-     * Parses the sender ID.
-     *
-     * @param value The value from config.
-     * @return The sender ID.
-     */
-    @Nullable
-    public static String parseSender(@Nullable String value) {
-        if (value == null) {
-            return null;
-        }
-
-        if (value.startsWith("sender:")) {
-            return value.substring(SENDER_PREFIX.length());
-        }
-
-        return value;
+    if (value.startsWith("sender:")) {
+      return value.substring(SENDER_PREFIX.length());
     }
 
-    /**
-     * Parses the config.xml file for any Urban Airship config.
-     *
-     * @param context The application context.
-     */
-    @NonNull
-    public static Map<String, String> parseConfigXml(@NonNull Context context) {
-        Map<String, String> config = new HashMap<String, String>();
-        int id = context.getResources().getIdentifier("config", "xml", context.getPackageName());
-        if (id == 0) {
-            return config;
-        }
+    return value;
+  }
 
-        XmlResourceParser xml = context.getResources().getXml(id);
-
-        int eventType = -1;
-        while (eventType != XmlResourceParser.END_DOCUMENT) {
-
-            if (eventType == XmlResourceParser.START_TAG) {
-                if (xml.getName().equals("preference")) {
-                    String name = xml.getAttributeValue(null, "name").toLowerCase(Locale.US);
-                    String value = xml.getAttributeValue(null, "value");
-
-                    if (name.startsWith(UA_PREFIX) && value != null) {
-                        config.put(name, value);
-                        PluginLogger.verbose("Found %s in config.xml with value: %s", name, value);
-                    }
-                }
-            }
-
-            try {
-                eventType = xml.next();
-            } catch (Exception e) {
-                PluginLogger.error(e, "Error parsing config file");
-            }
-        }
-
-        return config;
+  /**
+   * Parses the config.xml file for any Urban Airship config.
+   *
+   * @param context The application context.
+   */
+  @NonNull
+  public static Map<String, String> parseConfigXml(@NonNull Context context) {
+    Map<String, String> config = new HashMap<String, String>();
+    int id = context.getResources().getIdentifier("config", "xml", context.getPackageName());
+    if (id == 0) {
+      return config;
     }
+
+    XmlResourceParser xml = context.getResources().getXml(id);
+
+    int eventType = -1;
+    while (eventType != XmlResourceParser.END_DOCUMENT) {
+
+      if (eventType == XmlResourceParser.START_TAG) {
+        if (xml.getName().equals("preference")) {
+          String name = xml.getAttributeValue(null, "name").toLowerCase(Locale.US);
+          String value = xml.getAttributeValue(null, "value");
+
+          if (name.startsWith(UA_PREFIX) && value != null) {
+            config.put(name, value);
+            PluginLogger.verbose("Found %s in config.xml with value: %s", name, value);
+          }
+        }
+      }
+
+      try {
+        eventType = xml.next();
+      } catch (Exception e) {
+        PluginLogger.error(e, "Error parsing config file");
+      }
+    }
+
+    return config;
+  }
 }

--- a/src/android/ConfigUtils.java
+++ b/src/android/ConfigUtils.java
@@ -30,23 +30,21 @@ class ConfigUtils {
         if (logLevel == null || logLevel.length() == 0) {
             return defaultLogLevel;
         }
-        String logString = logLevel.trim().toLowerCase();
-        switch (logString) {
-            case "verbose":
-                return Log.VERBOSE;
-            case "debug":
-                return Log.DEBUG;
-            case "info":
-                return Log.INFO;
-            case "warn":
-                return Log.WARN;
-            case "error":
-                return Log.ERROR;
-            case "none":
-                return Log.ASSERT;
-            default:
-                return defaultLogLevel;
-        }
+				String logString = logLevel.trim().toLowerCase();
+				if (logString.equals("verbose")) {
+					return Log.VERBOSE;
+				} else if (logString.equals("debug")) {
+					return Log.DEBUG;
+				} else if (logString.equals("info")) {
+					return Log.INFO;
+				} else if (logString.equals("warn")) {
+					return Log.WARN;
+				} else if (logString.equals("error")) {
+					return Log.ERROR;
+				} else if (logString.equals("none")) {
+					return Log.ASSERT;
+				}
+				return defaultLogLevel;
     }
 
     /**
@@ -75,7 +73,7 @@ class ConfigUtils {
      */
     @NonNull
     public static Map<String, String> parseConfigXml(@NonNull Context context) {
-        Map<String, String> config = new HashMap<>();
+        Map<String, String> config = new HashMap<String, String>();
         int id = context.getResources().getIdentifier("config", "xml", context.getPackageName());
         if (id == 0) {
             return config;

--- a/src/android/PluginManager.java
+++ b/src/android/PluginManager.java
@@ -66,7 +66,7 @@ public class PluginManager {
     private NotificationOpenedEvent notificationOpenedEvent;
     private DeepLinkEvent deepLinkEvent = null;
     private Listener listener = null;
-    private final List<Event> pendingEvents = new ArrayList<>();
+    private final List<Event> pendingEvents = new ArrayList<Event>();
 
     private final SharedPreferences sharedPreferences;
     private final Map<String, String> defaultConfigValues;

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -608,7 +608,7 @@ public class UAirshipPlugin extends CordovaPlugin {
      * @param callbackContext The callback context.
      */
     void setTags(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
-        HashSet<String> tagSet = new HashSet<>();
+        HashSet<String> tagSet = new HashSet<String>();
         JSONArray tagsArray = data.getJSONArray(0);
         for (int i = 0; i < tagsArray.length(); ++i) {
             tagSet.add(tagsArray.getString(i));
@@ -853,7 +853,7 @@ public class UAirshipPlugin extends CordovaPlugin {
                              * it back to the user.
                              */
 
-                            Map<String, JsonValue> resultMap = new HashMap<>();
+                            Map<String, JsonValue> resultMap = new HashMap<String, JsonValue>();
                             resultMap.put("value", result.getValue().toJsonValue());
 
                             try {
@@ -906,7 +906,7 @@ public class UAirshipPlugin extends CordovaPlugin {
             String group = operation.getString("group");
             String operationType = operation.getString("operation");
 
-            HashSet<String> tagSet = new HashSet<>();
+            HashSet<String> tagSet = new HashSet<String>();
             for (int j = 0; j < tags.length(); j++) {
                 tagSet.add(tags.getString(j));
             }

--- a/src/android/Utils.java
+++ b/src/android/Utils.java
@@ -53,7 +53,7 @@ public class Utils {
     @NonNull
     public static JSONObject notificationObject(@NonNull PushMessage message, @Nullable String notificationTag, @Nullable Integer notificationId) throws JSONException {
         JSONObject data = new JSONObject();
-        Map<String, String> extras = new HashMap<>();
+        Map<String, String> extras = new HashMap<String, String>();
         for (String key : message.getPushBundle().keySet()) {
             if ("android.support.content.wakelockid".equals(key)) {
                 continue;


### PR DESCRIPTION
# Please fill out this template when submitting a pull request.
All lines beginning with an ℹ symbol indicate information that's important for you to provide to ensure your pull request is reviewed as quickly and efficiently as possible.

### What do these changes do?
Adds explicit types to diamond operators and removes string switch to allow plugin to build against older Cordova projects

### Why are these changes necessary?
1.6 does not support implied types in diamond operators or string switches

### How did you verify these changes?
Created a fork, made the changes, built a legacy project using these changes, verified the project worked.

#### Verification Screenshots:
ℹ If applicable, please provide screenshots here.

### Anything else a reviewer should know?
ℹ Please provide any additional notes for the reviewer here.