### PR TITLE
Release 7.5.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
 ==============================
-Version 7.5.4 - April 18, 2019
+Version 7.5.4 - April 19, 2019
 ==============================
-Added a gradle property `uaSkipApplyGoogleServicesPlugin` that will disable applying
+- Added a gradle property `uaSkipApplyGoogleServicesPlugin` that will disable applying
 the `GoogleServicesPlugin` if set to `true`. This option should only be used if another
 plugin also applies the `GoogleServicesPlugin` to avoid build errors.
+- Updated Airship iOS SDK to 10.2.2
 
 ==============================
 Version 7.5.3 - March 14, 2019

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,11 @@
 ==============================
+Version 7.5.4 - April 18, 2019
+==============================
+Added a gradle property `uaSkipApplyGoogleServicesPlugin` that will disable applying
+the `GoogleServicesPlugin` if set to `true`. This option should only be used if another
+plugin also applies the `GoogleServicesPlugin` to avoid build errors.
+
+==============================
 Version 7.5.3 - March 14, 2019
 ==============================
 Fixed a security issue within Android Urban Airship SDK, that could allow trusted

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ In order to take advantage of iOS 10 notification attachments, such as images,
 animated gifs, and video, you will need to create a [notification service extension](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension/)
 by following the [iOS Notification Service Extension Guide](https://docs.urbanairship.com/tutorials/api/ios/notification-service-extension/).
 
+### Android GoogleServicesPlugin
+
+The plugin will automatically apply the `GoogleServicesPlugin` for FCM. This can cause conflicts with other plugins that also apply
+the `GoogleServicesPlugin`. Applications can disable applying the plugin by setting the gradle property `uaSkipApplyGoogleServicesPlugin`
+to `true`. See (Setting Gradle Properties)[https://cordova.apache.org/docs/en/latest/guide/platforms/android/#setting-gradle-properties]
+for details on how to set a gradle property in a Cordova project.
+
+
 ### Sample
 
 A sample can be found in the Example directory.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "description": "Urban Airship Cordova plugin",
   "cordova": {
     "id": "urbanairship-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin id="urbanairship-cordova"
-        version="7.5.3"
+        version="7.5.4"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -354,7 +354,7 @@
         <resource-file src="src/ios/Airship/AirshipResources.bundle"/>
 
         <!-- Airship library -->
-        <source-file framework="true" src="src/ios/Airship/libUAirship-10.2.0.a"/>
+        <source-file framework="true" src="src/ios/Airship/libUAirship-10.2.2.a"/>
 
         <!-- System frameworks -->
         <framework src="libsqlite3.dylib" />

--- a/scripts/run_ci_tasks.sh
+++ b/scripts/run_ci_tasks.sh
@@ -67,7 +67,7 @@ if [ "$ANDROID" = "true" ]; then
   fi
 
   # Build android
-  cordova build android -- 2>&1 | tee -a /tmp/CORDOVA-$$.out
+  cordova build android -- ---gradleArg=-PuaInternalJava6CompileOptions=true 2>&1 | tee -a /tmp/CORDOVA-$$.out
 
   # check for failures
   if grep "BUILD FAILED" /tmp/CORDOVA-$$.out; then

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -38,3 +38,10 @@ if (project.hasProperty('uaInternalJava6CompileOptions') && uaInternalJava6Compi
     })
 }
 
+// Used to avoid conflicts with other plugins that also apply the GoogleServicesPlugin
+// See https://cordova.apache.org/docs/en/latest/guide/platforms/android/#setting-gradle-properties
+if (!project.hasProperty('uaSkipApplyGoogleServicesPlugin') || !uaSkipApplyGoogleServicesPlugin) {
+    cdvPluginPostBuildExtras.push({
+        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+    })
+}

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -28,6 +28,13 @@ dependencies {
 
 ext.cdvCompileSdkVersion = 28
 
-cdvPluginPostBuildExtras.push({
-    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-})
+// For CI only. Verify our plugin is Java 6 compatible
+if (project.hasProperty('uaInternalJava6CompileOptions') && uaInternalJava6CompileOptions.toBoolean()) {
+    cdvPluginPostBuildExtras.push({
+        android.compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+        }
+    })
+}
+


### PR DESCRIPTION
Adds Java6 CI check and an option to disable the GoogleServicesPlugin if another plugin is also adding it.

Doing a release since the README is being updated with the new gradle option.