### PR TITLE
[MOBILE-593] notification button/categories support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,19 +137,19 @@ Please visit http://support.urbanairship.com/ for any issues integrating or usin
 
 3. *(Optional)*  Add platform-specific custom notification button groups resource files to config.xml:
 ```
-        <!-- Optional: include custom notification button groups in XML format -->
-       <platform name="android">
-            ...
-            <resource-file src="ua_custom_notification_buttons.xml" target="app/src/main/res/xml/ua_custom_notification_buttons.xml" />
-       </platform>
+  <!-- Optional: include custom notification button groups in XML format -->
+  <platform name="android">
+      ...
+      <resource-file src="ua_custom_notification_buttons.xml" target="app/src/main/res/xml/ua_custom_notification_buttons.xml" />
+  </platform>
 
-        ...
+  ...
 
-        <!-- Optional: include custom notification categories in plist format -->
-       <platform name="ios">
-            ...
-            <resource-file src="UACustomNotificationCategories.plist" />
-       </platform>
+  <!-- Optional: include custom notification categories in plist format -->
+  <platform name="ios">
+      ...
+      <resource-file src="UACustomNotificationCategories.plist" />
+  </platform>
 ```
 
 ### iOS Notification Service Extension

--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ Please visit http://support.urbanairship.com/ for any issues integrating or usin
         document.addEventListener("urbanairship.notification_opened", notificationOpened)
         document.addEventListener("urbanairship.deep_link", handleDeepLink)
 
+3. *(Optional)*  Add platform-specific custom notification button groups resource files to config.xml:
+```
+        <!-- Optional: include custom notification button groups in XML format -->
+       <platform name="android">
+            ...
+            <resource-file src="ua_custom_notification_buttons.xml" target="app/src/main/res/xml/ua_custom_notification_buttons.xml" />
+       </platform>
+
+        ...
+
+        <!-- Optional: include custom notification categories in plist format -->
+       <platform name="ios">
+            ...
+            <resource-file src="UACustomNotificationCategories.plist" />
+       </platform>
+```
+
 ### iOS Notification Service Extension
 
 In order to take advantage of iOS 10 notification attachments, such as images,

--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -4,6 +4,7 @@ package com.urbanairship.cordova;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.XmlRes;
 
 import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.Autopilot;
@@ -105,6 +106,8 @@ public class CordovaAutopilot extends Autopilot {
             }
         });
 
+        loadCustomNotificationButtonGroups(context, airship);
+
         // Replace the message center actions to control auto launch behavior
         airship.getActionRegistry()
                 .getEntry(OverlayRichPushMessageAction.DEFAULT_REGISTRY_NAME)
@@ -113,6 +116,15 @@ public class CordovaAutopilot extends Autopilot {
         airship.getActionRegistry()
                 .getEntry(OpenRichPushInboxAction.DEFAULT_REGISTRY_NAME)
                 .setDefaultAction(new CustomOpenRichPushMessageAction());
+    }
+
+    private void loadCustomNotificationButtonGroups(Context context, UAirship airship) {
+        String packageName = UAirship.shared().getPackageName();
+        @XmlRes int resId = context.getResources().getIdentifier("ua_custom_notification_buttons", "xml", packageName);
+
+         if (resId != 0) {
+            airship.getPushManager().addNotificationActionButtonGroups(context, resId);
+        }
     }
 
     private static void sendShowInboxEvent(@NonNull ActionArguments arguments) {

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -31,6 +31,8 @@ NSString *const EventPushReceived = @"urbanairship.push";
 NSString *const EventNotificationOpened = @"urbanairship.notification_opened";
 NSString *const EventNotificationOptInStatus = @"urbanairship.notification_opt_in_status";
 
+NSString *const CategoriesPlistPath = @"UACustomNotificationCategories";
+
 NSString *const EventShowInbox = @"urbanairship.show_inbox";
 NSString *const EventInboxUpdated = @"urbanairship.inbox_updated";
 NSString *const EventRegistration = @"urbanairship.registration";
@@ -84,6 +86,8 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
         [[UAirship push] resetBadge];
     }
 
+    [self loadCustomNotificationCategories];
+
     [UAirship push].pushNotificationDelegate = self;
     [UAirship push].registrationDelegate = self;
     [UAirship inbox].delegate = self;
@@ -95,6 +99,17 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
                                                object:nil];
 
     self.isAirshipReady = YES;
+}
+
+- (void)loadCustomNotificationCategories {
+    NSString *categoriesPath = [[NSBundle mainBundle] pathForResource:CategoriesPlistPath ofType:@"plist"];
+    NSSet *customNotificationCategories = [UANotificationCategories createCategoriesFromFile:categoriesPath];
+
+    if (customNotificationCategories.count) {
+        UA_LDEBUG(@"Registering custom notification categories: %@", customNotificationCategories);
+        [UAirship push].customCategories = customNotificationCategories;
+        [[UAirship push] updateRegistration];
+    }
 }
 
 - (UAConfig *)createAirshipConfig {
@@ -335,7 +350,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
                                           NotificationPresentationAlertKey : @(alertBool),
                                           NotificationPresentationBadgeKey : @(badgeBool),
                                           NotificationPresentationSoundKey : @(soundBool)
-                                  },
+                                          },
                                   @"authorizedNotificationSettings" : @{
                                           AuthorizedNotificationSettingsAlertKey : @(alertBool),
                                           AuthorizedNotificationSettingsBadgeKey : @(badgeBool),
@@ -343,7 +358,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
                                           AuthorizedNotificationSettingsCarPlayKey : @(carPlayBool),
                                           AuthorizedNotificationSettingsLockScreenKey : @(lockScreenBool),
                                           AuthorizedNotificationSettingsNotificationCenterKey : @(notificationCenterBool)
-                                  }};
+                                          }};
 
     UA_LINFO(@"Opt in status changed.");
     [self fireEvent:EventNotificationOptInStatus data:eventBody];


### PR DESCRIPTION
### What do these changes do?
These changes add support for custom categories to facilitate customizing the buttons that appear inside interactive notifications. 

### Why are these changes necessary?
These changes are necessary to customize interactive notifications with buttons on the cordova platform. Prior to this work, one could only use the provided categories when choosing button types interactive notifications.

### How did you verify these changes?
Manually tested on both iOS and Android using the following payload:
https://gist.github.com/crow/144426d519ec41881a2f945887da7012

#### Verification Screenshots:
![image](https://user-images.githubusercontent.com/2199816/57988593-14189c00-7a45-11e9-8b17-fe448fd73ad4.png)

![image](https://user-images.githubusercontent.com/2199816/57988598-1e3a9a80-7a45-11e9-9294-25fd17de0523.png)

### Anything else a reviewer should know?
Documentation is here:
https://github.com/urbanairship/extdocs/pull/2842

Work is essentially the same as the react-native plugin here:
https://github.com/urbanairship/react-native-module/pull/179