### PR TITLE
[MOBILE-657] store pending events 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -209,6 +209,21 @@
         <source-file src="src/ios/UAMessageViewController.m"/>
         <header-file src="src/ios/UACordovaPluginManager.h"/>
         <source-file src="src/ios/UACordovaPluginManager.m"/>
+        <header-file src="src/ios/events/UACordovaEvent.h"/>
+        <header-file src="src/ios/events/UACordovaDeepLinkEvent.h"/>
+        <source-file src="src/ios/events/UACordovaDeepLinkEvent.m"/>
+        <header-file src="src/ios/events/UACordovaInboxUpdatedEvent.h"/>
+        <source-file src="src/ios/events/UACordovaInboxUpdatedEvent.m"/>
+        <header-file src="src/ios/events/UACordovaNotificationOpenedEvent.h"/>
+        <source-file src="src/ios/events/UACordovaNotificationOpenedEvent.m"/>
+        <header-file src="src/ios/events/UACordovaNotificationOptInEvent.h"/>
+        <source-file src="src/ios/events/UACordovaNotificationOptInEvent.m"/>
+        <header-file src="src/ios/events/UACordovaPushEvent.h"/>
+        <source-file src="src/ios/events/UACordovaPushEvent.m"/>
+        <header-file src="src/ios/events/UACordovaRegistrationEvent.h"/>
+        <source-file src="src/ios/events/UACordovaRegistrationEvent.m"/>
+        <header-file src="src/ios/events/UACordovaShowInboxEvent.h"/>
+        <source-file src="src/ios/events/UACordovaShowInboxEvent.m"/>
 
         <!-- Airship headers -->
         <header-file src="src/ios/Airship/Headers/AirshipLib.h" />

--- a/src/ios/UACordovaPluginManager.h
+++ b/src/ios/UACordovaPluginManager.h
@@ -10,8 +10,13 @@
 
 /**
  * Called to notify listeners of a new or pending event.
+ *
+ * @param eventType The event type string.
+ * @param data The json payload dictionary.
+ *
+ * @return `YES` if a properly implemented listener was notified, `NO` otherwise.
  */
--(void)notifyListener:(NSString *)eventType data:(NSDictionary *)data;
+-(BOOL)notifyListener:(NSString *)eventType data:(NSDictionary *)data;
 @end
 
 /**

--- a/src/ios/UACordovaPluginManager.h
+++ b/src/ios/UACordovaPluginManager.h
@@ -14,7 +14,7 @@
  * @param eventType The event type string.
  * @param data The json payload dictionary.
  *
- * @return `YES` if a properly implemented listener was notified, `NO` otherwise.
+ * @return `YES` if a listener was notified, `NO` otherwise.
  */
 -(BOOL)notifyListener:(NSString *)eventType data:(NSDictionary *)data;
 @end

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -295,6 +295,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 -(void)receivedDeepLink:(NSURL *_Nonnull)url completionHandler:(void (^_Nonnull)(void))completionHandler {
     self.lastReceivedDeepLink = [url absoluteString];
     [self fireEvent:[UACordovaDeepLinkEvent eventWithDeepLink:url]];
+    completionHandler();
 }
 
 #pragma mark UARegistrationDelegate

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -448,8 +448,12 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     id strongDelegate = self.delegate;
 
     if (strongDelegate && [strongDelegate notifyListener:event.type data:event.data]) {
+        UA_LTRACE(@"Cordova plugin manager delegate notified with event of type:%@ with data:%@", event.type, event.data);
+
         return;
     }
+
+    UA_LTRACE(@"No cordova plugin manager delegate available, storing pending event of type:%@ with data:%@", event.type, event.data);
 
     // Add pending event
     [self.pendingEvents addObject:event];
@@ -459,6 +463,8 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     _delegate = delegate;
 
     if (delegate) {
+        UA_LTRACE(@"Cordova plugin manager delegate set:%@", delegate);
+
         NSDictionary *events = [self.pendingEvents copy];
         [self.pendingEvents removeAllObjects];
 

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -35,16 +35,8 @@ NSString *const AuthorizedNotificationSettingsLockScreenKey = @"lockScreen";
 NSString *const AuthorizedNotificationSettingsNotificationCenterKey = @"notificationCenter";
 
 // Events
-NSString *const EventPushReceived = @"urbanairship.push";
-NSString *const EventNotificationOpened = @"urbanairship.notification_opened";
-NSString *const EventNotificationOptInStatus = @"urbanairship.notification_opt_in_status";
-
 NSString *const CategoriesPlistPath = @"UACustomNotificationCategories";
 
-NSString *const EventShowInbox = @"urbanairship.show_inbox";
-NSString *const EventInboxUpdated = @"urbanairship.inbox_updated";
-NSString *const EventRegistration = @"urbanairship.registration";
-NSString *const EventDeepLink = @"urbanairship.deep_link";
 
 @interface UACordovaPluginManager() <UARegistrationDelegate, UAPushNotificationDelegate, UAInboxDelegate, UADeepLinkDelegate>
 @property (nonatomic, strong) NSDictionary *defaultConfig;

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -456,13 +456,15 @@ NSString *const CategoriesPlistPath = @"UACustomNotificationCategories";
     _delegate = delegate;
 
     if (delegate) {
-        UA_LTRACE(@"Cordova plugin manager delegate set:%@", delegate);
+        @synchronized(self.pendingEvents) {
+            UA_LTRACE(@"Cordova plugin manager delegate set:%@", delegate);
 
-        NSDictionary *events = [self.pendingEvents copy];
-        [self.pendingEvents removeAllObjects];
+            NSDictionary *events = [self.pendingEvents copy];
+            [self.pendingEvents removeAllObjects];
 
-        for (NSObject<UACordovaEvent> *event in events) {
-            [self fireEvent:event];
+            for (NSObject<UACordovaEvent> *event in events) {
+                [self fireEvent:event];
+            }
         }
     }
 }

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -2,6 +2,14 @@
 
 #import "UACordovaPluginManager.h"
 #import "AirshipLib.h"
+#import "UACordovaEvent.h"
+#import "UACordovaDeepLinkEvent.h"
+#import "UACordovaInboxUpdatedEvent.h"
+#import "UACordovaNotificationOpenedEvent.h"
+#import "UACordovaNotificationOptInEvent.h"
+#import "UACordovaPushEvent.h"
+#import "UACordovaRegistrationEvent.h"
+#import "UACordovaShowInboxEvent.h"
 
 // Config keys
 NSString *const ProductionAppKeyConfigKey = @"com.urbanairship.production_app_key";
@@ -40,7 +48,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 
 @interface UACordovaPluginManager() <UARegistrationDelegate, UAPushNotificationDelegate, UAInboxDelegate, UADeepLinkDelegate>
 @property (nonatomic, strong) NSDictionary *defaultConfig;
-@property (nonatomic, strong) NSMutableDictionary *pendingEvents;
+@property (nonatomic, strong) NSMutableArray<NSObject<UACordovaEvent> *> *pendingEvents;
 @property (nonatomic, assign) BOOL isAirshipReady;
 
 @end
@@ -58,7 +66,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 
     if (self) {
         self.defaultConfig = defaultConfig;
-        self.pendingEvents = [NSMutableDictionary dictionary];
+        self.pendingEvents = [NSMutableArray array];
     }
 
     return self;
@@ -204,7 +212,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     if (self.autoLaunchMessageCenter) {
         [[UAirship messageCenter] displayMessageForID:messageID];
     } else {
-        [self fireEvent:EventShowInbox data:@{@"messageId":messageID}];
+        [self fireEvent:[UACordovaShowInboxEvent eventWithMessageID:messageID]];
     }
 }
 
@@ -212,13 +220,13 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     if (self.autoLaunchMessageCenter) {
         [[UAirship messageCenter] display];
     } else {
-        [self fireEvent:EventShowInbox data:@{}];
+        [self fireEvent:[UACordovaShowInboxEvent event]];
     }
 }
 
 - (void)inboxUpdated {
     UA_LDEBUG(@"Inbox updated");
-    [self fireEvent:EventInboxUpdated data:@{}];
+    [self fireEvent:[UACordovaInboxUpdatedEvent event]];
 }
 
 #pragma mark UAPushNotificationDelegate
@@ -226,8 +234,9 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 -(void)receivedForegroundNotification:(UANotificationContent *)notificationContent completionHandler:(void (^)(void))completionHandler {
     UA_LDEBUG(@"Received a notification while the app was already in the foreground %@", notificationContent);
 
-    id event = [self pushEventFromNotification:notificationContent];
-    [self fireEvent:EventPushReceived data:event];
+    NSDictionary *data = [self pushEventFromNotification:notificationContent];
+
+    [self fireEvent:[UACordovaPushEvent eventWithData:data]];
 
     completionHandler();
 }
@@ -236,30 +245,31 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
                      completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
     UA_LDEBUG(@"Received a background notification %@", notificationContent);
-    id event = [self pushEventFromNotification:notificationContent];
+    NSDictionary *data = [self pushEventFromNotification:notificationContent];
 
-    [self fireEvent:EventPushReceived data:event];
+    [self fireEvent:[UACordovaPushEvent eventWithData:data]];
     completionHandler(UIBackgroundFetchResultNoData);
 }
 
 -(void)receivedNotificationResponse:(UANotificationResponse *)notificationResponse completionHandler:(void (^)(void))completionHandler {
     UA_LDEBUG(@"The application was launched or resumed from a notification %@", notificationResponse);
     NSDictionary *pushEvent = [self pushEventFromNotification:notificationResponse.notificationContent];
-    NSMutableDictionary *event = [NSMutableDictionary dictionaryWithDictionary:pushEvent];
+    NSMutableDictionary *data = [NSMutableDictionary dictionaryWithDictionary:pushEvent];
 
     if ([notificationResponse.actionIdentifier isEqualToString:UANotificationDefaultActionIdentifier]) {
-        [event setValue:@(YES) forKey:@"isForeground"];
+        [data setValue:@(YES) forKey:@"isForeground"];
     } else {
         UANotificationAction *notificationAction = [self notificationActionForCategory:notificationResponse.notificationContent.categoryIdentifier
                                                                       actionIdentifier:notificationResponse.actionIdentifier];
 
         BOOL isForeground = notificationAction.options & UNNotificationActionOptionForeground;
-        [event setValue:@(isForeground) forKey:@"isForeground"];
-        [event setValue:notificationResponse.actionIdentifier forKey:@"actionID"];
+        [data setValue:@(isForeground) forKey:@"isForeground"];
+        [data setValue:notificationResponse.actionIdentifier forKey:@"actionID"];
     }
 
-    self.lastReceivedNotificationResponse = event;
-    [self fireEvent:EventNotificationOpened data:event];
+    self.lastReceivedNotificationResponse = data;
+
+    [self fireEvent:[UACordovaNotificationOpenedEvent eventWithData:data]];
     completionHandler();
 }
 
@@ -284,8 +294,7 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
 #pragma mark UADeepLinkDelegate
 -(void)receivedDeepLink:(NSURL *_Nonnull)url completionHandler:(void (^_Nonnull)(void))completionHandler {
     self.lastReceivedDeepLink = [url absoluteString];
-    NSDictionary *data = @{ @"deepLink":[url absoluteString]};
-    [self fireEvent:EventDeepLink data:data];
+    [self fireEvent:[UACordovaDeepLinkEvent eventWithDeepLink:url]];
 }
 
 #pragma mark UARegistrationDelegate
@@ -300,12 +309,13 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
         data = @{ @"channelID":channelID };
     }
 
-    [self fireEvent:EventRegistration data:data];
+    [self fireEvent:[UACordovaRegistrationEvent eventWithData:data]];
 }
 
 - (void)registrationFailed {
     UA_LINFO(@"Channel registration failed.");
-    [self fireEvent:EventRegistration data:@{ @"error": @"Registration failed." }];
+    UACordovaRegistrationEvent *event = [UACordovaRegistrationEvent eventWithData:@{ @"error": @"Registration failed." }];
+    [self fireEvent:event];
 }
 
 - (void)notificationAuthorizedSettingsDidChange:(UAAuthorizedNotificationSettings)authorizedSettings {
@@ -361,7 +371,8 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
                                           }};
 
     UA_LINFO(@"Opt in status changed.");
-    [self fireEvent:EventNotificationOptInStatus data:eventBody];
+    UACordovaNotificationOptInEvent *event = [UACordovaNotificationOptInEvent eventWithData:eventBody];
+    [self fireEvent:event];
 }
 
 - (NSDictionary *)pushEventFromNotification:(UANotificationContent *)notificationContent {
@@ -433,12 +444,15 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
     return notificationAction;
 }
 
-
-- (void)fireEvent:(NSString *)type data:(NSDictionary *)data {
+- (void)fireEvent:(NSObject<UACordovaEvent> *)event {
     id strongDelegate = self.delegate;
-    if (strongDelegate) {
-        [strongDelegate notifyListener:type data:data];
+
+    if (strongDelegate && [strongDelegate notifyListener:event.type data:event.data]) {
+        return;
     }
+
+    // Add pending event
+    [self.pendingEvents addObject:event];
 }
 
 - (void)setDelegate:(id<UACordovaPluginManagerDelegate>)delegate {
@@ -448,8 +462,8 @@ NSString *const EventDeepLink = @"urbanairship.deep_link";
         NSDictionary *events = [self.pendingEvents copy];
         [self.pendingEvents removeAllObjects];
 
-        for (NSString *eventType in events) {
-            [self fireEvent:eventType data:events[eventType]];
+        for (NSObject<UACordovaEvent> *event in events) {
+            [self fireEvent:event];
         }
     }
 }

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -761,10 +761,10 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     }];
 }
 
-- (void)notifyListener:(NSString *)eventType data:(NSDictionary *)data {
+- (BOOL)notifyListener:(NSString *)eventType data:(NSDictionary *)data {
     if (!self.listenerCallbackID) {
         UA_LTRACE(@"Listener callback unavailable.  event %@", eventType);
-        return;
+        return false;
     }
 
     NSMutableDictionary *message = [NSMutableDictionary dictionary];
@@ -775,6 +775,8 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     [result setKeepCallbackAsBool:YES];
 
     [self.commandDelegate sendPluginResult:result callbackId:self.listenerCallbackID];
+
+    return true;
 }
 
 @end

--- a/src/ios/events/UACordovaDeepLinkEvent.h
+++ b/src/ios/events/UACordovaDeepLinkEvent.h
@@ -1,0 +1,37 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaEvent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const EventDeepLink;
+
+/**
+ * Deep link event when a new deep link is received.
+ */
+@interface UACordovaDeepLinkEvent : NSObject<UACordovaEvent>
+
+/**
+ * The event type.
+ *
+ * @return The event type.
+ */
+@property (nonatomic, strong, nullable) NSString *type;
+
+/**
+ * The event data.
+ *
+ * @return The event data.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *data;
+
+/**
+ * Deep link event when a new deep link is received.
+ *
+ * @param deepLink The deep link url.
+ */
++ (instancetype)eventWithDeepLink:(NSURL *)deepLink;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/events/UACordovaDeepLinkEvent.m
+++ b/src/ios/events/UACordovaDeepLinkEvent.m
@@ -7,19 +7,6 @@ NSString *const DeepLinkKey = @"deepLink";
 
 @implementation UACordovaDeepLinkEvent
 
-+ (instancetype)event {
-    return [[UACordovaDeepLinkEvent alloc] init];
-}
-
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        self.type = EventDeepLink;
-        self.data = nil;
-    }
-    return self;
-}
-
 + (instancetype)eventWithDeepLink:(NSURL *)deepLink {
     return [[UACordovaDeepLinkEvent alloc] initWithDeepLink:deepLink];
 }

--- a/src/ios/events/UACordovaDeepLinkEvent.m
+++ b/src/ios/events/UACordovaDeepLinkEvent.m
@@ -1,0 +1,36 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaDeepLinkEvent.h"
+
+NSString *const EventDeepLink = @"urbanairship.deep_link";
+NSString *const DeepLinkKey = @"deepLink";
+
+@implementation UACordovaDeepLinkEvent
+
++ (instancetype)event {
+    return [[UACordovaDeepLinkEvent alloc] init];
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.type = EventDeepLink;
+        self.data = nil;
+    }
+    return self;
+}
+
++ (instancetype)eventWithDeepLink:(NSURL *)deepLink {
+    return [[UACordovaDeepLinkEvent alloc] initWithDeepLink:deepLink];
+}
+
+- (instancetype)initWithDeepLink:(NSURL *)deepLink {
+    self = [super init];
+    if (self) {
+        self.data = @{DeepLinkKey:[deepLink absoluteString]};
+        self.type = EventDeepLink;
+    }
+    return self;
+}
+
+@end

--- a/src/ios/events/UACordovaEvent.h
+++ b/src/ios/events/UACordovaEvent.h
@@ -1,0 +1,28 @@
+/* Copyright Urban Airship and Contributors */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Interface for Urban Airship Cordova events.
+ */
+@protocol UACordovaEvent <NSObject>
+
+/**
+ * The event type.
+ *
+ * @return The event type.
+ */
+@property (nonatomic, strong, nullable) NSString *type;
+
+/**
+ * The event data.
+ *
+ * @return The event data.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/events/UACordovaInboxUpdatedEvent.h
+++ b/src/ios/events/UACordovaInboxUpdatedEvent.h
@@ -1,0 +1,38 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaEvent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const EventInboxUpdated;
+
+/**
+ * Inbox update event.
+ */
+@interface UACordovaInboxUpdatedEvent : NSObject<UACordovaEvent>
+
+/**
+ * The event type.
+ *
+ * @return The event type.
+ */
+@property (nonatomic, strong, nullable) NSString *type;
+
+/**
+ * The event data.
+ *
+ * @return The event data.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *data;
+
+/**
+ * The default event.
+ *
+ * @return The default event.
+ */
++ (instancetype)event;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/events/UACordovaInboxUpdatedEvent.m
+++ b/src/ios/events/UACordovaInboxUpdatedEvent.m
@@ -1,0 +1,23 @@
+/* Copyright Urban Airship and Contributors */
+
+
+#import "UACordovaInboxUpdatedEvent.h"
+
+NSString *const EventInboxUpdated = @"urbanairship.inbox_updated";
+
+@implementation UACordovaInboxUpdatedEvent
+
++ (instancetype)event {
+    return [[UACordovaInboxUpdatedEvent alloc ] init];
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.data = nil;
+        self.type = EventInboxUpdated;
+    }
+    return self;
+}
+
+@end

--- a/src/ios/events/UACordovaInboxUpdatedEvent.m
+++ b/src/ios/events/UACordovaInboxUpdatedEvent.m
@@ -1,6 +1,5 @@
 /* Copyright Urban Airship and Contributors */
 
-
 #import "UACordovaInboxUpdatedEvent.h"
 
 NSString *const EventInboxUpdated = @"urbanairship.inbox_updated";
@@ -8,7 +7,7 @@ NSString *const EventInboxUpdated = @"urbanairship.inbox_updated";
 @implementation UACordovaInboxUpdatedEvent
 
 + (instancetype)event {
-    return [[UACordovaInboxUpdatedEvent alloc ] init];
+    return [[UACordovaInboxUpdatedEvent alloc] init];
 }
 
 - (instancetype)init {

--- a/src/ios/events/UACordovaNotificationOpenedEvent.h
+++ b/src/ios/events/UACordovaNotificationOpenedEvent.h
@@ -1,0 +1,37 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaEvent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const EventNotificationOpened;
+
+/**
+ * Notification opened event.
+ */
+@interface UACordovaNotificationOpenedEvent : NSObject<UACordovaEvent>
+
+/**
+ * The event type.
+ *
+ * @return The event type.
+ */
+@property (nonatomic, strong, nullable) NSString *type;
+
+/**
+ * The event data.
+ *
+ * @return The event data.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *data;
+
+/**
+ * Push event with event data.
+ *
+ * @param data The event data.
+ */
++ (instancetype)eventWithData:(NSDictionary *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/events/UACordovaNotificationOpenedEvent.h
+++ b/src/ios/events/UACordovaNotificationOpenedEvent.h
@@ -26,7 +26,7 @@ extern NSString *const EventNotificationOpened;
 @property (nonatomic, strong, nullable) NSDictionary *data;
 
 /**
- * Push event with event data.
+ * Open event with event data.
  *
  * @param data The event data.
  */

--- a/src/ios/events/UACordovaNotificationOpenedEvent.m
+++ b/src/ios/events/UACordovaNotificationOpenedEvent.m
@@ -6,15 +6,6 @@ NSString *const EventNotificationOpened = @"urbanairship.notification_opened";
 
 @implementation UACordovaNotificationOpenedEvent
 
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        self.data = nil;
-        self.type = EventNotificationOpened;
-    }
-    return self;
-}
-
 + (instancetype)eventWithData:(NSDictionary *)data  {
     return [[UACordovaNotificationOpenedEvent alloc] initWithData:data];
 }

--- a/src/ios/events/UACordovaNotificationOpenedEvent.m
+++ b/src/ios/events/UACordovaNotificationOpenedEvent.m
@@ -1,0 +1,31 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaNotificationOpenedEvent.h"
+
+NSString *const EventNotificationOpened = @"urbanairship.notification_opened";
+
+@implementation UACordovaNotificationOpenedEvent
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.data = nil;
+        self.type = EventNotificationOpened;
+    }
+    return self;
+}
+
++ (instancetype)eventWithData:(NSDictionary *)data  {
+    return [[UACordovaNotificationOpenedEvent alloc] initWithData:data];
+}
+
+- (instancetype)initWithData:(NSDictionary *)data {
+    self = [super init];
+    if (self) {
+        self.type = EventNotificationOpened;
+        self.data = data;
+    }
+    return self;
+}
+
+@end

--- a/src/ios/events/UACordovaNotificationOptInEvent.h
+++ b/src/ios/events/UACordovaNotificationOptInEvent.h
@@ -1,0 +1,37 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaEvent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const EventNotificationOptInStatus;
+
+/**
+ * Notification opt-in status event.
+ */
+@interface UACordovaNotificationOptInEvent : NSObject<UACordovaEvent>
+
+/**
+ * The event type.
+ *
+ * @return The event type.
+ */
+@property (nonatomic, strong, nullable) NSString *type;
+
+/**
+ * The event data.
+ *
+ * @return The event data.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *data;
+
+/**
+ * The opt-in event constructor.
+ *
+ * @return The event opt-in event.
+ */
++ (instancetype)eventWithData:(NSDictionary *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/events/UACordovaNotificationOptInEvent.m
+++ b/src/ios/events/UACordovaNotificationOptInEvent.m
@@ -1,0 +1,22 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaNotificationOptInEvent.h"
+
+NSString *const EventNotificationOptInStatus = @"urbanairship.notification_opt_in_status";
+
+@implementation UACordovaNotificationOptInEvent
+
++ (instancetype)eventWithData:(NSDictionary *)data  {
+    return [[UACordovaNotificationOptInEvent alloc] initWithData:data];
+}
+
+- (instancetype)initWithData:(NSDictionary *)data {
+    self = [super init];
+    if (self) {
+        self.type = EventNotificationOptInStatus;
+        self.data = data;
+    }
+    return self;
+}
+
+@end

--- a/src/ios/events/UACordovaPushEvent.h
+++ b/src/ios/events/UACordovaPushEvent.h
@@ -1,0 +1,37 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaEvent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const EventPushReceived;
+
+/**
+ * Push event.
+ */
+@interface UACordovaPushEvent : NSObject<UACordovaEvent>
+
+/**
+ * The event type.
+ *
+ * @return The event type.
+ */
+@property (nonatomic, strong, nullable) NSString *type;
+
+/**
+ * The event data.
+ *
+ * @return The event data.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *data;
+
+/**
+ * Push event with event data.
+ *
+ * @param data The event data.
+ */
++ (instancetype)eventWithData:(NSDictionary *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/events/UACordovaPushEvent.m
+++ b/src/ios/events/UACordovaPushEvent.m
@@ -1,0 +1,22 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaPushEvent.h"
+
+NSString *const EventPushReceived = @"urbanairship.push";
+
+@implementation UACordovaPushEvent
+
++ (instancetype)eventWithData:(NSDictionary *)data  {
+    return [[UACordovaPushEvent alloc] initWithData:data];
+}
+
+- (instancetype)initWithData:(NSDictionary *)data {
+    self = [super init];
+    if (self) {
+        self.type = EventPushReceived;
+        self.data = data;
+    }
+    return self;
+}
+
+@end

--- a/src/ios/events/UACordovaRegistrationEvent.h
+++ b/src/ios/events/UACordovaRegistrationEvent.h
@@ -1,0 +1,37 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaEvent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const EventRegistration;
+
+/**
+ * Registration event.
+ */
+@interface UACordovaRegistrationEvent : NSObject<UACordovaEvent>
+
+/**
+ * The event type.
+ *
+ * @return The event type.
+ */
+@property (nonatomic, strong, nullable) NSString *type;
+
+/**
+ * The event data.
+ *
+ * @return The event data.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *data;
+
+/**
+ * The registration event constructor.
+ *
+ * @return registration event.
+ */
++ (instancetype)eventWithData:(NSDictionary *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/events/UACordovaRegistrationEvent.m
+++ b/src/ios/events/UACordovaRegistrationEvent.m
@@ -1,0 +1,22 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaRegistrationEvent.h"
+
+NSString *const EventRegistration = @"urbanairship.registration";
+
+@implementation UACordovaRegistrationEvent
+
++ (instancetype)eventWithData:(NSDictionary *)data  {
+    return [[UACordovaRegistrationEvent alloc] initWithData:data];
+}
+
+- (instancetype)initWithData:(NSDictionary *)data {
+    self = [super init];
+    if (self) {
+        self.type = EventRegistration;
+        self.data = data;
+    }
+    return self;
+}
+
+@end

--- a/src/ios/events/UACordovaShowInboxEvent.h
+++ b/src/ios/events/UACordovaShowInboxEvent.h
@@ -1,0 +1,44 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaEvent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const EventShowInbox;
+
+/**
+ * Show inbox event.
+ */
+@interface UACordovaShowInboxEvent : NSObject<UACordovaEvent>
+
+/**
+ * The event type.
+ *
+ * @return The event type.
+ */
+@property (nonatomic, strong, nullable) NSString *type;
+
+/**
+ * The event data.
+ *
+ * @return The event data.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *data;
+
+/**
+ * Show default inbox event
+ *
+ * @return The default inbox event.
+ */
++ (instancetype)event;
+
+/**
+ * Show inbox event with message id.
+ *
+ * @return The inbox event with message identifier data.
+ */
++ (instancetype)eventWithMessageID:(NSString *)identifier;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/events/UACordovaShowInboxEvent.m
+++ b/src/ios/events/UACordovaShowInboxEvent.m
@@ -7,7 +7,7 @@ NSString *const EventShowInbox = @"urbanairship.show_inbox";
 @implementation UACordovaShowInboxEvent
 
 + (instancetype)event {
-    return [[UACordovaShowInboxEvent alloc] init];
+    return [[UACordovaShowInboxEvent alloc] initWithMessageID:nil];
 }
 
 + (instancetype)eventWithMessageID:(NSString *)identifier {
@@ -23,7 +23,7 @@ NSString *const EventShowInbox = @"urbanairship.show_inbox";
     return self;
 }
 
-- (instancetype)initWithMessageID:(NSString *)identifier {
+- (instancetype)initWithMessageID:(nullable NSString *)identifier {
     self = [super init];
     if (self) {
         self.type = EventShowInbox;

--- a/src/ios/events/UACordovaShowInboxEvent.m
+++ b/src/ios/events/UACordovaShowInboxEvent.m
@@ -1,0 +1,36 @@
+/* Copyright Urban Airship and Contributors */
+
+#import "UACordovaShowInboxEvent.h"
+
+NSString *const EventShowInbox = @"urbanairship.show_inbox";
+
+@implementation UACordovaShowInboxEvent
+
++ (instancetype)event {
+    return [[UACordovaShowInboxEvent alloc] init];
+}
+
++ (instancetype)eventWithMessageID:(NSString *)identifier {
+    return [[UACordovaShowInboxEvent alloc] initWithMessageID:identifier];
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.type = EventShowInbox;
+        self.data = nil;
+    }
+    return self;
+}
+
+- (instancetype)initWithMessageID:(NSString *)identifier {
+    self = [super init];
+    if (self) {
+        self.type = EventShowInbox;
+        self.data = @{@"messageId":identifier};
+    }
+
+    return self;
+}
+
+@end


### PR DESCRIPTION
### What do these changes do?
These changes change how we package events to facilitate pending event storage. This matches the android implementation for the most part. Prior to this work, pending events were not being stored.

### Why are these changes necessary?
These changes are necessary to improve event reliability in situations where events would otherwise be dropped before the listener was ready to receive notifications.

This potentially addresses the following issue.
https://github.com/urbanairship/urbanairship-cordova/issues/302

### How did you verify these changes?
Manually tested the sample.

### Anything else a reviewer should know?
The deep link event has a slightly different structure than the rest. This is because the way its data payload is constructed is relatively simple. In future work, we should move all the data management logic from the plugin manager to the events themselves. I've excluded said work from this pr to reduce its complexity and mitigate the extra risk.