### PR TITLE
[MOBILE-402] adds support for custom notification channels

### DIFF
--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -182,6 +182,7 @@ public class CordovaAutopilot extends Autopilot {
         });
 
         loadCustomNotificationButtonGroups(context, airship);
+        loadCustomNotificationChannels(context, airship);
     }
 
     private void loadCustomNotificationButtonGroups(Context context, UAirship airship) {
@@ -192,6 +193,17 @@ public class CordovaAutopilot extends Autopilot {
             airship.getPushManager().addNotificationActionButtonGroups(context, resId);
         }
     }
+
+    private void loadCustomNotificationChannels(Context context, UAirship airship) {
+        String packageName = UAirship.shared().getPackageName();
+        @XmlRes int resId = context.getResources().getIdentifier("ua_custom_notification_channels", "xml", packageName);
+
+        if (resId != 0) {
+            PluginLogger.debug("Loading custom notification channels");
+            airship.getPushManager().getNotificationChannelRegistry().createNotificationChannels(resId);
+        }
+    }
+
     private static void sendShowInboxEvent(@NonNull String messageId) {
         Context context = UAirship.getApplicationContext();
         PluginManager.shared(context).sendShowInboxEvent(new ShowInboxEvent(messageId));

--- a/src/android/CordovaAutopilot.java
+++ b/src/android/CordovaAutopilot.java
@@ -190,7 +190,8 @@ public class CordovaAutopilot extends Autopilot {
         @XmlRes int resId = context.getResources().getIdentifier("ua_custom_notification_buttons", "xml", packageName);
 
          if (resId != 0) {
-            airship.getPushManager().addNotificationActionButtonGroups(context, resId);
+             PluginLogger.debug("Loading custom notification button groups");
+             airship.getPushManager().addNotificationActionButtonGroups(context, resId);
         }
     }
 


### PR DESCRIPTION
### What do these changes do?
These changes adds support for custom notification channels. It uses the same approach as adding the notification button groups. This means the custom notification channels are loaded from XML.

### Why are these changes necessary?
To support custom notification channels.

### How did you verify these changes?
Ran the sample with changes in place. Cross referenced with notification button groups and react-native implementation.

### Anything else a reviewer should know?
This won't pass tests until the following repo is public:
https://github.com/urbanairship/airship-location-cordova/tree/master/src

Extdocs documentation forthcoming.