### PR TITLE
[MOBILE-404] Allow setting the default notification channel ID

### DIFF
--- a/src/android/PluginManager.java
+++ b/src/android/PluginManager.java
@@ -59,7 +59,9 @@ public class PluginManager {
     private static final String NOTIFICATION_SOUND = "com.urbanairship.notification_sound";
     static final String AUTO_LAUNCH_MESSAGE_CENTER = "com.urbanairship.auto_launch_message_center";
     private static final String ENABLE_ANALYTICS = "com.urbanairship.enable_analytics";
+
     private static final String NOTIFICATION_OPT_IN_STATUS_EVENT_PREFERENCES_KEY = "com.urbanairship.notification_opt_in_status_preferences";
+    private static final String DEFAULT_NOTIFICATION_CHANNEL_ID  = "com.urbanairship.default_notification_channel_id";
 
     private static PluginManager instance;
     private final Object lock = new Object();
@@ -154,6 +156,23 @@ public class PluginManager {
                     .apply();
             notifyListener(new NotificationOptInEvent(optIn));
         }
+    }
+
+    /**
+     * Gets the default notification channel ID.
+     * @return The default notification channel ID.
+     */
+    @Nullable
+    public String getDefaultNotificationChannelId() {
+        return sharedPreferences.getString(DEFAULT_NOTIFICATION_CHANNEL_ID, null);
+    }
+
+    /**
+     * Sets the default notification channel ID.
+     * @param value The value.
+     */
+    public void setDefaultNotificationChannelId(@Nullable String value) {
+        sharedPreferences.edit().putString(DEFAULT_NOTIFICATION_CHANNEL_ID, value).apply();
     }
 
     /**
@@ -580,6 +599,22 @@ public class PluginManager {
                 editor.remove(NOTIFICATION_ACCENT_COLOR);
             } else {
                 editor.putString(NOTIFICATION_ACCENT_COLOR, accentColor);
+            }
+            return this;
+        }
+
+        /**
+         * Sets the default notification channel ID.
+         *
+         * @param value The string value.
+         * @return The config editor.
+         */
+        @NonNull
+        public ConfigEditor setDefaultNotificationChannelId(@Nullable String value) {
+            if (value == null) {
+                editor.remove(DEFAULT_NOTIFICATION_CHANNEL_ID);
+            } else {
+                editor.putString(DEFAULT_NOTIFICATION_CHANNEL_ID, value);
             }
             return this;
         }

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -89,6 +89,11 @@ public class UAirshipPlugin extends CordovaPlugin {
     private final static List<String> GLOBAL_ACTIONS = Arrays.asList("takeOff", "registerListener", "setAndroidNotificationConfig");
     private final ExecutorService executorService = Executors.newFixedThreadPool(1);
 
+    private static final String NOTIFICATION_ICON_KEY = "icon";
+    private static final String NOTIFICATION_LARGE_ICON_KEY = "largeIcon";
+    private static final String ACCENT_COLOR_KEY = "accentColor";
+    private static final String DEFAULT_CHANNEL_ID_KEY = "defaultChannelId";
+
     private Context context;
     private PluginManager pluginManager;
 
@@ -251,9 +256,10 @@ public class UAirshipPlugin extends CordovaPlugin {
 
         // Factory will pull the latest values from the config.
         pluginManager.editConfig()
-                .setNotificationIcon(config.optString("icon"))
-                .setNotificationLargeIcon(config.optString("largeIcon"))
-                .setNotificationAccentColor(config.optString("accentColor"))
+                .setNotificationIcon(config.optString(NOTIFICATION_ICON_KEY))
+                .setNotificationLargeIcon(config.optString(NOTIFICATION_LARGE_ICON_KEY))
+                .setNotificationAccentColor(config.optString(ACCENT_COLOR_KEY))
+                .setDefaultNotificationChannelId(config.optString(DEFAULT_CHANNEL_ID_KEY))
                 .apply();
 
         callbackContext.success();


### PR DESCRIPTION
### What do these changes do?
Allows setting the default notification channel ID in preferences both directly and from the config.

### Why are these changes necessary?
To allow setting the default notification channel ID.

### How did you verify these changes?
generating, running the android sample

![image](https://user-images.githubusercontent.com/2199816/59389121-671eff80-8d22-11e9-89f1-8c3a1b416896.png)
