### PR TITLE
[MOBILE-919] fix jsdoc regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/parser": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-      "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+      "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
       "dev": true
     },
     "adm-zip": {
@@ -32,9 +32,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
+      "integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
       "dev": true
     },
     "catharsis": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "co-prompt": "^1.0.0",
     "commander": "^2.19.0",
     "fs": "0.0.1-security",
-    "jsdoc": "3.6.3",
+    "jsdoc": "^3.6.3",
     "minami": "1.2.3",
     "semver": "^5.6.0",
     "superagent": "^4.1.0"

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -1,13 +1,8 @@
 /* Copyright Urban Airship and Contributors */
 
-/**
- * @module UrbanAirship
- */
-
 var cardova = require("cordova"),
     exec = require("cordova/exec"),
     argscheck = require('cordova/argscheck')
-
 
 // Argcheck values:
 // * : allow anything,
@@ -116,6 +111,9 @@ function bindDocumentEvent() {
 
 document.addEventListener("deviceready", bindDocumentEvent, false)
 
+/**
+ * @module UrbanAirship
+ */
 module.exports = {
 
   /**


### PR DESCRIPTION
The last Cordova plugin update introduced a regression causing incomplete documentation output for TagGroupEditor. That change was also, in part, an attempt to deal with incomplete (missing) output for the main UrbanAirship module. Here's what I think was going on:

Moving the module annotation to the top of the file got the docs for the main module to generate correctly, but at the expense of the TagGroupEditor. I think that change wasn't a fix so much as it shifted the problem around. In my own testing, after reverting that change, I managed to boil it down to the way the script was run. Running the jsdoc command manually resulted in the correct output, and running it via `npm run` resulted in the broken output. The two versions of jsdoc were otherwise identical.

The one thing that finally worked for me was to uninstall and reinstall jsdoc:
`npm uninstall jsdoc`
`npm install --save-dev jsdoc`

You'll notice in the diff for package-lock.json that doing this quietly updated a couple of its dependencies. My hunch is that when we previously updated it to 3.6.3, the version number for jsdoc was edited directly in the package.json file, as opposed to running npm install, and so the packaged version of jsdoc was running with incompatible versions of these dependencies. Let this be a warning to all ye who walk this path in the future. 

Screenshots of happy jsdoc output below.

<img width="1340" alt="happy-jsdoc-1" src="https://user-images.githubusercontent.com/545958/66354815-d98f9d00-e91a-11e9-8d74-0b2b7bff9a7c.png">
<img width="1341" alt="happy-jsdoc-2" src="https://user-images.githubusercontent.com/545958/66354819-dbf1f700-e91a-11e9-8583-beb99773f20e.png">
<img width="1342" alt="happy-jsdoc-3" src="https://user-images.githubusercontent.com/545958/66354824-deece780-e91a-11e9-90d1-0144603c8237.png">
 