### PR TITLE
[MOBILE-663] event constructor refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+Version 9.0.0 - October 14, 2019
+================================
+
+- Updated iOS Airship SDK to 12.0.0
+- Updated iOS minimum deployment target to 11.0
+- Fixed overlayInboxMessage crash on iOS
+
 ==================================
 Version 8.1.0 - September 23, 2019
 ==================================

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You would only run `pod repo update` if you have the specs-repo already cloned o
  - cococapods >= 1.7.3
 
 #### iOS:
-- Xcode 10+
+- Xcode 11+
 - [APNS Setup](https://docs.airship.com/platform/ios/getting-started/#apple-setup)
 
 #### Android
@@ -171,7 +171,7 @@ You would only run `pod repo update` if you have the specs-repo already cloned o
 
 ### iOS Notification Service Extension
 
-In order to take advantage of iOS 10 notification attachments, such as images,
+In order to take advantage of iOS notification attachments, such as images,
 animated gifs, and video, you will need to create a [notification service extension](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension/)
 by following the [iOS Notification Service Extension Guide](https://docs.airship.com/platform/ios/getting-started/#notification-service-extension).
 

--- a/config_sample.xml
+++ b/config_sample.xml
@@ -31,8 +31,8 @@
 <!-- If the app is in production or not -->
 <preference name="com.urbanairship.in_production" value="false" />
 
-<!-- Deployment target must be >= iOS 10  -->
-<preference name="deployment-target" value="10.0" />
+<!-- Deployment target must be >= iOS 11  -->
+<preference name="deployment-target" value="11.0" />
 
 <!-- Optional config values -->
 <!-- Enable push when the application launches -->
@@ -49,10 +49,10 @@
 <preference name="com.urbanairship.notification_accent_color" value="#0000ff" />
 <!-- Clear the iOS badge on launch -->
 <preference name="com.urbanairship.clear_badge_onlaunch" value="true" />
-<!-- iOS 10 alert foreground notification presentation option -->
+<!-- Alert foreground notification presentation option -->
 <preference name="com.urbanairship.ios_foreground_notification_presentation_alert" value="true"/>
-<!-- iOS 10 badge foreground notification presentation option -->
+<!-- Badge foreground notification presentation option -->
 <preference name="com.urbanairship.ios_foreground_notification_presentation_badge" value="true"/>
-<!-- iOS 10 sound foreground notification presentation option -->
+<!-- Sound foreground notification presentation option -->
 <preference name="com.urbanairship.ios_foreground_notification_presentation_sound" value="true"/>
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Urban Airship Cordova plugin",
   "cordova": {
     "id": "urbanairship-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -185,7 +185,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="UrbanAirship-iOS-SDK" spec="11.1.2" />
+                <pod name="UrbanAirship-iOS-SDK" spec="12.0.0" />
             </pods>
         </podspec>
 

--- a/src/ios/UACordovaPluginManager.h
+++ b/src/ios/UACordovaPluginManager.h
@@ -94,12 +94,5 @@
  */
 - (void)setPresentationOptions:(NSUInteger)options;
 
-/**
- * Generates a push event dictionary from a notification content object.
- *
- * @param notificationContent The notification content.
- * @return A push event dictionary.
- */
-- (NSDictionary *)pushEventFromNotification:(UANotificationContent *)notificationContent;
-
 @end
+

--- a/src/ios/UACordovaPluginManager.h
+++ b/src/ios/UACordovaPluginManager.h
@@ -10,6 +10,8 @@
 @import AirshipKit;
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Manager delegate.
  */
@@ -39,7 +41,7 @@
 /**
  * Last received deep link.
  */
-@property (nonatomic, copy) NSString *lastReceivedDeepLink;
+@property (nonatomic, copy, nullable) NSString *lastReceivedDeepLink;
 
 /**
  * Flag that enables/disables auto launching the default message center.
@@ -49,7 +51,7 @@
 /**
  * Last received notification response.
  */
-@property (nonatomic, copy) NSDictionary *lastReceivedNotificationResponse;
+@property (nonatomic, copy, nullable) NSDictionary *lastReceivedNotificationResponse;
 
 /**
  * Checks if Airship is ready.
@@ -96,3 +98,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -237,38 +237,6 @@
 - (void)isAnalyticsEnabled:(CDVInvokedUrlCommand *)command;
 
 /**
- * Enables or disables location.
- *
- * Expected arguments: Boolean
- *
- * @param command The cordova command.
- */
-- (void)setLocationEnabled:(CDVInvokedUrlCommand *)command;
-
-/**
- * Checks if location is enabled or not.
- *
- * @param command The cordova command.
- */
-- (void)isLocationEnabled:(CDVInvokedUrlCommand *)command;
-
-/**
- * Enables or disables background location.
- *
- * Expected arguments: Boolean
- *
- * @param command The cordova command.
- */
-- (void)setBackgroundLocationEnabled:(CDVInvokedUrlCommand *)command;
-
-/**
- * Checks if background location is enabled or not.
- *
- * @param command The cordova command.
- */
-- (void)isBackgroundLocationEnabled:(CDVInvokedUrlCommand *)command;
-
-/**
  * Runs an Urban Airship action.
  *
  * Expected arguments: String - action name, * - the action value

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -3,6 +3,7 @@
 #import "UAirshipPlugin.h"
 #import "UAMessageViewController.h"
 #import "UACordovaPluginManager.h"
+#import "UACordovaPushEvent.h"
 
 typedef void (^UACordovaCompletionHandler)(CDVCommandStatus, id);
 typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandler completionHandler);
@@ -784,7 +785,7 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
                 NSMutableArray *result = [NSMutableArray array];
                 for(UNNotification *unnotification in notifications) {
                     UANotificationContent *content = [UANotificationContent notificationWithUNNotification:unnotification];
-                    [result addObject:[self.pluginManager pushEventFromNotification:content]];
+                    [result addObject:[UACordovaPushEvent pushEventDataFromNotificationContent:content]];
                 }
 
                 completionHandler(CDVCommandStatus_OK, result);

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -53,8 +53,9 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
 
     // String
     if ([value isKindOfClass:[NSString class]]) {
+        NSCharacterSet *characters = [NSCharacterSet URLHostAllowedCharacterSet];
         return [CDVPluginResult resultWithStatus:status
-                                 messageAsString:[value stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+                                 messageAsString:[value stringByAddingPercentEncodingWithAllowedCharacters:characters]];
     }
 
     // Number
@@ -347,7 +348,7 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     UA_LTRACE("getChannelID called with command arguments: %@", command.arguments);
 
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        completionHandler(CDVCommandStatus_OK, [UAirship push].channelID ?: @"");
+        completionHandler(CDVCommandStatus_OK, [UAirship channel].identifier ?: @"");
     }];
 }
 
@@ -395,7 +396,7 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     UA_LTRACE("getTags called with command arguments: %@", command.arguments);
 
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        completionHandler(CDVCommandStatus_OK, [UAirship push].tags ?: [NSArray array]);
+        completionHandler(CDVCommandStatus_OK, [UAirship channel].tags ?: [NSArray array]);
     }];
 }
 
@@ -420,8 +421,8 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
 
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
         NSMutableArray *tags = [NSMutableArray arrayWithArray:[args objectAtIndex:0]];
-        [UAirship push].tags = tags;
-        [[UAirship push] updateRegistration];
+        [UAirship channel].tags = tags;
+        [[UAirship channel] updateRegistration];
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
@@ -521,9 +522,9 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
         for (NSDictionary *operation in [args objectAtIndex:0]) {
             NSString *group = operation[@"group"];
             if ([operation[@"operation"] isEqualToString:@"add"]) {
-                [[UAirship push] addTags:operation[@"tags"] group:group];
+                [[UAirship channel] addTags:operation[@"tags"] group:group];
             } else if ([operation[@"operation"] isEqualToString:@"remove"]) {
-                [[UAirship push] removeTags:operation[@"tags"] group:group];
+                [[UAirship channel] removeTags:operation[@"tags"] group:group];
             }
         }
 
@@ -757,10 +758,44 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
             return;
         }
 
-        [self overlayInboxMessage:message];
+        [self showOverlayMessage:message];
 
         completionHandler(CDVCommandStatus_OK, nil);
     }];
+}
+
+- (void)showOverlayMessage:(UAInboxMessage *)message {
+    UA_LTRACE(@"Displaying overlay message:%@", message);
+
+    if (!self.factoryBlockAssigned) {
+        [[UAirship inAppMessageManager] setFactoryBlock:^id<UAInAppMessageAdapterProtocol> _Nonnull(UAInAppMessage * _Nonnull message) {
+            UAInAppMessageHTMLAdapter *adapter = [UAInAppMessageHTMLAdapter adapterForMessage:message];
+            UAInAppMessageHTMLDisplayContent *displayContent = (UAInAppMessageHTMLDisplayContent *) message.displayContent;
+            NSURL *url = [NSURL URLWithString:displayContent.url];
+
+            if ([url.scheme isEqualToString:@"message"]) {
+                self.htmlAdapter = adapter;
+            }
+
+            return adapter;
+        } forDisplayType:UAInAppMessageDisplayTypeHTML];
+
+        self.factoryBlockAssigned = YES;
+    }
+
+    [UAActionRunner runActionWithName:kUAOverlayInboxMessageActionDefaultRegistryName
+                                value:message.messageID
+                            situation:UASituationManualInvocation];
+}
+
+- (void)closeOverlayMessage {
+    UA_LTRACE(@"closeOverlayMessage called");
+
+    UIViewController *vc = [self.htmlAdapter valueForKey:@"htmlViewController"];
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [vc performSelector:NSSelectorFromString(@"dismissWithoutResolution")];
+# pragma clang diagnostic pop
 }
 
 - (void)refreshInbox:(CDVInvokedUrlCommand *)command {
@@ -842,40 +877,6 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     [self.commandDelegate sendPluginResult:result callbackId:self.listenerCallbackID];
 
     return true;
-}
-
-- (void)displayOverlayMessage:(UAInboxMessage *)message {
-    UA_LTRACE(@"Displaying overlay message:%@", message);
-
-    if (!self.factoryBlockAssigned) {
-        [[UAirship inAppMessageManager] setFactoryBlock:^id<UAInAppMessageAdapterProtocol> _Nonnull(UAInAppMessage * _Nonnull message) {
-            UAInAppMessageHTMLAdapter *adapter = [UAInAppMessageHTMLAdapter adapterForMessage:message];
-            UAInAppMessageHTMLDisplayContent *displayContent = (UAInAppMessageHTMLDisplayContent *) message.displayContent;
-            NSURL *url = [NSURL URLWithString:displayContent.url];
-
-            if ([url.scheme isEqualToString:@"message"]) {
-                self.htmlAdapter = adapter;
-            }
-
-            return adapter;
-        } forDisplayType:UAInAppMessageDisplayTypeHTML];
-
-        self.factoryBlockAssigned = YES;
-    }
-
-    [UAActionRunner runActionWithName:kUAOverlayInboxMessageActionDefaultRegistryName
-                                value:message.messageID
-                            situation:UASituationManualInvocation];
-}
-
-- (void)closeOverlayMessage {
-    UA_LTRACE(@"closeOverlayMessage called");
-
-    UIViewController *vc = [self.htmlAdapter valueForKey:@"htmlViewController"];
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    [vc performSelector:NSSelectorFromString(@"dismissWithoutResolution")];
-# pragma clang diagnostic pop
 }
 
 @end

--- a/src/ios/events/UACordovaNotificationOpenedEvent.h
+++ b/src/ios/events/UACordovaNotificationOpenedEvent.h
@@ -1,6 +1,6 @@
 /* Copyright Urban Airship and Contributors */
 
-#import "UACordovaEvent.h"
+#import "UACordovaPushEvent.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -9,28 +9,14 @@ extern NSString *const EventNotificationOpened;
 /**
  * Notification opened event.
  */
-@interface UACordovaNotificationOpenedEvent : NSObject<UACordovaEvent>
+@interface UACordovaNotificationOpenedEvent : UACordovaPushEvent
 
 /**
- * The event type.
+ * Notification opened event with notification response.
  *
- * @return The event type.
- */
-@property (nonatomic, strong, nullable) NSString *type;
-
-/**
- * The event data.
- *
- * @return The event data.
- */
-@property (nonatomic, strong, nullable) NSDictionary *data;
-
-/**
- * Open event with event data.
- *
- * @param data The event data.
- */
-+ (instancetype)eventWithData:(NSDictionary *)data;
+ * @param content The notification response.
+*/
++ (instancetype)eventWithNotificationResponse:(UANotificationResponse *)response;
 
 @end
 

--- a/src/ios/events/UACordovaNotificationOpenedEvent.m
+++ b/src/ios/events/UACordovaNotificationOpenedEvent.m
@@ -1,22 +1,82 @@
 /* Copyright Urban Airship and Contributors */
 
+#if __has_include(<AirshipKit/AirshipLib.h>)
+#import <AirshipKit/AirshipLib.h>
+#elif __has_include("AirshipLib.h")
+#import "AirshipLib.h"
+#else
+@import AirshipKit;
+#endif
+
 #import "UACordovaNotificationOpenedEvent.h"
 
 NSString *const EventNotificationOpened = @"urbanairship.notification_opened";
 
 @implementation UACordovaNotificationOpenedEvent
 
-+ (instancetype)eventWithData:(NSDictionary *)data  {
-    return [[UACordovaNotificationOpenedEvent alloc] initWithData:data];
-}
-
-- (instancetype)initWithData:(NSDictionary *)data {
+- (instancetype)initWithNotificationResponse:(UANotificationResponse *)response {
     self = [super init];
+
     if (self) {
         self.type = EventNotificationOpened;
+
+        NSDictionary *pushEvent = [[self class] pushEventDataFromNotificationContent:response.notificationContent];
+        NSMutableDictionary *data = [NSMutableDictionary dictionaryWithDictionary:pushEvent];
+
+        if ([response.actionIdentifier isEqualToString:UANotificationDefaultActionIdentifier]) {
+            [data setValue:@(YES) forKey:@"isForeground"];
+        } else {
+            UANotificationAction *notificationAction = [self notificationActionForCategory:response.notificationContent.categoryIdentifier
+                                                                          actionIdentifier:response.actionIdentifier];
+
+            BOOL isForeground = notificationAction.options & UNNotificationActionOptionForeground;
+            [data setValue:@(isForeground) forKey:@"isForeground"];
+            [data setValue:response.actionIdentifier forKey:@"actionID"];
+        }
+
         self.data = data;
     }
+
     return self;
+}
+
++ (instancetype)eventWithNotificationResponse:(UANotificationResponse *)response {
+    return [[self alloc] initWithNotificationResponse:response];
+}
+
+- (UANotificationAction *)notificationActionForCategory:(NSString *)category actionIdentifier:(NSString *)identifier {
+    NSSet *categories = [UAirship push].combinedCategories;
+
+    UANotificationCategory *notificationCategory;
+    UANotificationAction *notificationAction;
+
+    for (UANotificationCategory *possibleCategory in categories) {
+        if ([possibleCategory.identifier isEqualToString:category]) {
+            notificationCategory = possibleCategory;
+            break;
+        }
+    }
+
+    if (!notificationCategory) {
+        UA_LERR(@"Unknown notification category identifier %@", category);
+        return nil;
+    }
+
+    NSMutableArray *possibleActions = [NSMutableArray arrayWithArray:notificationCategory.actions];
+
+    for (UANotificationAction *possibleAction in possibleActions) {
+        if ([possibleAction.identifier isEqualToString:identifier]) {
+            notificationAction = possibleAction;
+            break;
+        }
+    }
+
+    if (!notificationAction) {
+        UA_LERR(@"Unknown notification action identifier %@", identifier);
+        return nil;
+    }
+
+    return notificationAction;
 }
 
 @end

--- a/src/ios/events/UACordovaNotificationOptInEvent.h
+++ b/src/ios/events/UACordovaNotificationOptInEvent.h
@@ -1,5 +1,13 @@
 /* Copyright Urban Airship and Contributors */
 
+#if __has_include(<AirshipKit/AirshipLib.h>)
+#import <AirshipKit/AirshipLib.h>
+#elif __has_include("AirshipLib.h")
+#import "AirshipLib.h"
+#else
+@import AirshipKit;
+#endif
+
 #import "UACordovaEvent.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -28,9 +36,10 @@ extern NSString *const EventNotificationOptInStatus;
 /**
  * The opt-in event constructor.
  *
+ * @param authorizedSettings The authorized notification settings
  * @return The event opt-in event.
  */
-+ (instancetype)eventWithData:(NSDictionary *)data;
++ (instancetype)eventWithAuthorizedSettings:(UAAuthorizedNotificationSettings)authorizedSettings;
 
 @end
 

--- a/src/ios/events/UACordovaNotificationOptInEvent.m
+++ b/src/ios/events/UACordovaNotificationOptInEvent.m
@@ -4,19 +4,77 @@
 
 NSString *const EventNotificationOptInStatus = @"urbanairship.notification_opt_in_status";
 
+NSString *const UACordovaNotificationOptInEventAlertKey = @"alert";
+NSString *const UACordovaNotificationOptInEventBadgeKey = @"badge";
+NSString *const UACordovaNotificationOptInEventSoundKey = @"sound";
+NSString *const UACordovaNotificationOptInEventCarPlayKey = @"carPlay";
+NSString *const UACordovaNotificationOptInEventLockScreenKey = @"lockScreen";
+NSString *const UACordovaNotificationOptInEventNotificationCenterKey = @"notificationCenter";
+
 @implementation UACordovaNotificationOptInEvent
 
-+ (instancetype)eventWithData:(NSDictionary *)data  {
-    return [[UACordovaNotificationOptInEvent alloc] initWithData:data];
++ (instancetype)eventWithAuthorizedSettings:(UAAuthorizedNotificationSettings)authorizedSettings {
+    return [[UACordovaNotificationOptInEvent alloc] initWithAuthorizedSettings:authorizedSettings];
 }
 
-- (instancetype)initWithData:(NSDictionary *)data {
+- (instancetype)initWithAuthorizedSettings:(UAAuthorizedNotificationSettings)authorizedSettings {
     self = [super init];
+
     if (self) {
         self.type = EventNotificationOptInStatus;
-        self.data = data;
+        self.data = [self eventDataForAuthorizedSettings:authorizedSettings];
     }
+
     return self;
+}
+
+- (NSDictionary *)eventDataForAuthorizedSettings:(UAAuthorizedNotificationSettings)authorizedSettings {
+    BOOL optedIn = NO;
+
+    BOOL alertBool = NO;
+    BOOL badgeBool = NO;
+    BOOL soundBool = NO;
+    BOOL carPlayBool = NO;
+    BOOL lockScreenBool = NO;
+    BOOL notificationCenterBool = NO;
+
+    if (authorizedSettings & UAAuthorizedNotificationSettingsAlert) {
+        alertBool = YES;
+    }
+
+    if (authorizedSettings & UAAuthorizedNotificationSettingsBadge) {
+        badgeBool = YES;
+    }
+
+    if (authorizedSettings & UAAuthorizedNotificationSettingsSound) {
+        soundBool = YES;
+    }
+
+    if (authorizedSettings & UAAuthorizedNotificationSettingsCarPlay) {
+        carPlayBool = YES;
+    }
+
+    if (authorizedSettings & UAAuthorizedNotificationSettingsLockScreen) {
+        lockScreenBool = YES;
+    }
+
+    if (authorizedSettings & UAAuthorizedNotificationSettingsNotificationCenter) {
+        notificationCenterBool = YES;
+    }
+
+    optedIn = authorizedSettings != UAAuthorizedNotificationSettingsNone;
+
+    NSDictionary *eventBody = @{  @"optIn": @(optedIn),
+                                  @"authorizedNotificationSettings" : @{
+                                          UACordovaNotificationOptInEventAlertKey : @(alertBool),
+                                          UACordovaNotificationOptInEventBadgeKey : @(badgeBool),
+                                          UACordovaNotificationOptInEventSoundKey : @(soundBool),
+                                          UACordovaNotificationOptInEventCarPlayKey : @(carPlayBool),
+                                          UACordovaNotificationOptInEventLockScreenKey : @(lockScreenBool),
+                                          UACordovaNotificationOptInEventNotificationCenterKey : @(notificationCenterBool)
+                                  }};
+
+    return eventBody;
 }
 
 @end

--- a/src/ios/events/UACordovaPushEvent.h
+++ b/src/ios/events/UACordovaPushEvent.h
@@ -1,5 +1,13 @@
 /* Copyright Urban Airship and Contributors */
 
+#if __has_include(<AirshipKit/AirshipLib.h>)
+#import <AirshipKit/AirshipLib.h>
+#elif __has_include("AirshipLib.h")
+#import "AirshipLib.h"
+#else
+@import AirshipKit;
+#endif
+
 #import "UACordovaEvent.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -26,11 +34,19 @@ extern NSString *const EventPushReceived;
 @property (nonatomic, strong, nullable) NSDictionary *data;
 
 /**
- * Push event with event data.
+ * Push event with notification content.
  *
- * @param data The event data.
+ * @param content The notification content.
  */
-+ (instancetype)eventWithData:(NSDictionary *)data;
++ (instancetype)eventWithNotificationContent:(UANotificationContent *)content;
+
+/**
+ * Helper method for producing sanitized push payloads from notification content.
+ *
+ * @param notificationContent The notification content.
+ * @return A push payload dictionary.
+ */
++ (NSDictionary *)pushEventDataFromNotificationContent:(UANotificationContent *)notificationContent;
 
 @end
 

--- a/src/ios/events/UACordovaPushEvent.m
+++ b/src/ios/events/UACordovaPushEvent.m
@@ -6,17 +6,53 @@ NSString *const EventPushReceived = @"urbanairship.push";
 
 @implementation UACordovaPushEvent
 
-+ (instancetype)eventWithData:(NSDictionary *)data  {
-    return [[UACordovaPushEvent alloc] initWithData:data];
++ (instancetype)eventWithNotificationContent:(UANotificationContent *)content  {
+    return [[self alloc] initWithNotificationContent:content];
 }
 
-- (instancetype)initWithData:(NSDictionary *)data {
+- (instancetype)initWithNotificationContent:(UANotificationContent *)content {
     self = [super init];
+
     if (self) {
         self.type = EventPushReceived;
-        self.data = data;
+        self.data = [[self class] pushEventDataFromNotificationContent:content];
     }
+
     return self;
+}
+
++ (NSDictionary *)pushEventDataFromNotificationContent:(UANotificationContent *)notificationContent {
+    if (!notificationContent) {
+        return @{ @"message": @"", @"extras": @{}};
+    }
+
+    NSMutableDictionary *info = [NSMutableDictionary dictionaryWithDictionary:notificationContent.notificationInfo];
+
+    // remove the send ID
+    if([[info allKeys] containsObject:@"_"]) {
+        [info removeObjectForKey:@"_"];
+    }
+
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+
+    // If there is an aps dictionary in the extras, remove it and set it as a top level object
+    if([[info allKeys] containsObject:@"aps"]) {
+        result[@"aps"] = info[@"aps"];
+        [info removeObjectForKey:@"aps"];
+    }
+
+    result[@"message"] = notificationContent.alertBody ?: @"";
+
+    // Set the title and subtitle as top level objects, if present
+    NSString *title = notificationContent.alertTitle;
+    NSString *subtitle = notificationContent.notification.request.content.subtitle;
+    [result setValue:title forKey:@"title"];
+    [result setValue:subtitle forKey:@"subtitle"];
+
+    // Set the remaining info as extras
+    result[@"extras"] = info;
+
+    return result;
 }
 
 @end

--- a/src/ios/events/UACordovaRegistrationEvent.h
+++ b/src/ios/events/UACordovaRegistrationEvent.h
@@ -26,11 +26,20 @@ extern NSString *const EventRegistration;
 @property (nonatomic, strong, nullable) NSDictionary *data;
 
 /**
- * The registration event constructor.
+ * The registration succeeded event constructor.
  *
+ * @param channelID The channel ID.
+ * @param deviceToken The device token.
  * @return registration event.
  */
-+ (instancetype)eventWithData:(NSDictionary *)data;
++ (instancetype)registrationSucceededEventWithChannelID:channelID deviceToken:(NSString *)deviceToken;
+
+/**
+ * The registration failed event constructor.
+ *
+ * @return registration event.
+*/
++ (instancetype)registrationFailedEvent;
 
 @end
 

--- a/src/ios/events/UACordovaRegistrationEvent.m
+++ b/src/ios/events/UACordovaRegistrationEvent.m
@@ -6,8 +6,12 @@ NSString *const EventRegistration = @"urbanairship.registration";
 
 @implementation UACordovaRegistrationEvent
 
-+ (instancetype)eventWithData:(NSDictionary *)data  {
-    return [[UACordovaRegistrationEvent alloc] initWithData:data];
++ (instancetype)registrationSucceededEventWithChannelID:channelID deviceToken:(NSString *)deviceToken {
+    return [[self alloc] initWithData:[self registrationSucceededData:channelID deviceToken:deviceToken]];
+}
+
++ (instancetype)registrationFailedEvent {
+    return [[self alloc] initWithData:[self registrationFailedData]];
 }
 
 - (instancetype)initWithData:(NSDictionary *)data {
@@ -17,6 +21,22 @@ NSString *const EventRegistration = @"urbanairship.registration";
         self.data = data;
     }
     return self;
+}
+
++ (NSDictionary *)registrationSucceededData:(NSString *)channelID deviceToken:(NSString *)deviceToken {
+    NSDictionary *data;
+
+    if (deviceToken) {
+        data = @{ @"channelID":channelID, @"deviceToken":deviceToken, @"registrationToken":deviceToken };
+    } else {
+        data = @{ @"channelID":channelID };
+    }
+
+    return data;
+}
+
++ (NSDictionary *)registrationFailedData {
+    return @{ @"error": @"Registration failed." };
 }
 
 @end

--- a/src/ios/events/UACordovaShowInboxEvent.m
+++ b/src/ios/events/UACordovaShowInboxEvent.m
@@ -27,7 +27,7 @@ NSString *const EventShowInbox = @"urbanairship.show_inbox";
     self = [super init];
     if (self) {
         self.type = EventShowInbox;
-        self.data = @{@"messageId":identifier};
+        self.data = identifier ? @{@"messageId":identifier} : @{};
     }
 
     return self;


### PR DESCRIPTION
We have a few events using `eventWithData:` as a convenience constructor, and this has resulted in a situation where the plugin manager needs to know a bit too much about the shape of event data for its own good. This PR refactors those classes to take only the information they need to construct their own event data internally. Aside from the constructor changes, most of the diff is just helper methods being moved around. There's also a minor change to the opt-in event format that I'll leave a comment on below.

I'm still putting this through its paces as far as manual testing goes. In the meanwhile, have a look and see if this all makes sense. 