### PR TITLE
MOBILE-896 Update cordova plugin to iOS SDK 12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+Version 9.0.0 - October 14, 2019
+================================
+
+- Updated iOS Airship SDK to 12.0.0
+- Updated iOS minimum deployment target to 11.0
+- Fixed overlayInboxMessage crash on iOS
+
 ==================================
 Version 8.1.0 - September 23, 2019
 ==================================

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You would only run `pod repo update` if you have the specs-repo already cloned o
  - cococapods >= 1.7.3
 
 #### iOS:
-- Xcode 10+
+- Xcode 11+
 - [APNS Setup](https://docs.airship.com/platform/ios/getting-started/#apple-setup)
 
 #### Android
@@ -171,7 +171,7 @@ You would only run `pod repo update` if you have the specs-repo already cloned o
 
 ### iOS Notification Service Extension
 
-In order to take advantage of iOS 10 notification attachments, such as images,
+In order to take advantage of iOS notification attachments, such as images,
 animated gifs, and video, you will need to create a [notification service extension](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension/)
 by following the [iOS Notification Service Extension Guide](https://docs.airship.com/platform/ios/getting-started/#notification-service-extension).
 

--- a/config_sample.xml
+++ b/config_sample.xml
@@ -31,8 +31,8 @@
 <!-- If the app is in production or not -->
 <preference name="com.urbanairship.in_production" value="false" />
 
-<!-- Deployment target must be >= iOS 10  -->
-<preference name="deployment-target" value="10.0" />
+<!-- Deployment target must be >= iOS 11  -->
+<preference name="deployment-target" value="11.0" />
 
 <!-- Optional config values -->
 <!-- Enable push when the application launches -->
@@ -49,10 +49,10 @@
 <preference name="com.urbanairship.notification_accent_color" value="#0000ff" />
 <!-- Clear the iOS badge on launch -->
 <preference name="com.urbanairship.clear_badge_onlaunch" value="true" />
-<!-- iOS 10 alert foreground notification presentation option -->
+<!-- Alert foreground notification presentation option -->
 <preference name="com.urbanairship.ios_foreground_notification_presentation_alert" value="true"/>
-<!-- iOS 10 badge foreground notification presentation option -->
+<!-- Badge foreground notification presentation option -->
 <preference name="com.urbanairship.ios_foreground_notification_presentation_badge" value="true"/>
-<!-- iOS 10 sound foreground notification presentation option -->
+<!-- Sound foreground notification presentation option -->
 <preference name="com.urbanairship.ios_foreground_notification_presentation_sound" value="true"/>
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Urban Airship Cordova plugin",
   "cordova": {
     "id": "urbanairship-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -185,7 +185,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="UrbanAirship-iOS-SDK" spec="11.1.2" />
+                <pod name="UrbanAirship-iOS-SDK" spec="12.0.0" />
             </pods>
         </podspec>
 

--- a/src/ios/UACordovaPluginManager.h
+++ b/src/ios/UACordovaPluginManager.h
@@ -10,6 +10,8 @@
 @import AirshipKit;
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Manager delegate.
  */
@@ -39,7 +41,7 @@
 /**
  * Last received deep link.
  */
-@property (nonatomic, copy) NSString *lastReceivedDeepLink;
+@property (nonatomic, copy, nullable) NSString *lastReceivedDeepLink;
 
 /**
  * Flag that enables/disables auto launching the default message center.
@@ -49,7 +51,7 @@
 /**
  * Last received notification response.
  */
-@property (nonatomic, copy) NSDictionary *lastReceivedNotificationResponse;
+@property (nonatomic, copy, nullable) NSDictionary *lastReceivedNotificationResponse;
 
 /**
  * Checks if Airship is ready.
@@ -96,3 +98,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -53,8 +53,9 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
 
     // String
     if ([value isKindOfClass:[NSString class]]) {
+        NSCharacterSet *characters = [NSCharacterSet URLHostAllowedCharacterSet];
         return [CDVPluginResult resultWithStatus:status
-                                 messageAsString:[value stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+                                 messageAsString:[value stringByAddingPercentEncodingWithAllowedCharacters:characters]];
     }
 
     // Number
@@ -347,7 +348,7 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     UA_LTRACE("getChannelID called with command arguments: %@", command.arguments);
 
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        completionHandler(CDVCommandStatus_OK, [UAirship push].channelID ?: @"");
+        completionHandler(CDVCommandStatus_OK, [UAirship channel].identifier ?: @"");
     }];
 }
 
@@ -395,7 +396,7 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     UA_LTRACE("getTags called with command arguments: %@", command.arguments);
 
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
-        completionHandler(CDVCommandStatus_OK, [UAirship push].tags ?: [NSArray array]);
+        completionHandler(CDVCommandStatus_OK, [UAirship channel].tags ?: [NSArray array]);
     }];
 }
 
@@ -420,8 +421,8 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
 
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
         NSMutableArray *tags = [NSMutableArray arrayWithArray:[args objectAtIndex:0]];
-        [UAirship push].tags = tags;
-        [[UAirship push] updateRegistration];
+        [UAirship channel].tags = tags;
+        [[UAirship channel] updateRegistration];
         completionHandler(CDVCommandStatus_OK, nil);
     }];
 }
@@ -521,9 +522,9 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
         for (NSDictionary *operation in [args objectAtIndex:0]) {
             NSString *group = operation[@"group"];
             if ([operation[@"operation"] isEqualToString:@"add"]) {
-                [[UAirship push] addTags:operation[@"tags"] group:group];
+                [[UAirship channel] addTags:operation[@"tags"] group:group];
             } else if ([operation[@"operation"] isEqualToString:@"remove"]) {
-                [[UAirship push] removeTags:operation[@"tags"] group:group];
+                [[UAirship channel] removeTags:operation[@"tags"] group:group];
             }
         }
 
@@ -757,10 +758,44 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
             return;
         }
 
-        [self overlayInboxMessage:message];
+        [self showOverlayMessage:message];
 
         completionHandler(CDVCommandStatus_OK, nil);
     }];
+}
+
+- (void)showOverlayMessage:(UAInboxMessage *)message {
+    UA_LTRACE(@"Displaying overlay message:%@", message);
+
+    if (!self.factoryBlockAssigned) {
+        [[UAirship inAppMessageManager] setFactoryBlock:^id<UAInAppMessageAdapterProtocol> _Nonnull(UAInAppMessage * _Nonnull message) {
+            UAInAppMessageHTMLAdapter *adapter = [UAInAppMessageHTMLAdapter adapterForMessage:message];
+            UAInAppMessageHTMLDisplayContent *displayContent = (UAInAppMessageHTMLDisplayContent *) message.displayContent;
+            NSURL *url = [NSURL URLWithString:displayContent.url];
+
+            if ([url.scheme isEqualToString:@"message"]) {
+                self.htmlAdapter = adapter;
+            }
+
+            return adapter;
+        } forDisplayType:UAInAppMessageDisplayTypeHTML];
+
+        self.factoryBlockAssigned = YES;
+    }
+
+    [UAActionRunner runActionWithName:kUAOverlayInboxMessageActionDefaultRegistryName
+                                value:message.messageID
+                            situation:UASituationManualInvocation];
+}
+
+- (void)closeOverlayMessage {
+    UA_LTRACE(@"closeOverlayMessage called");
+
+    UIViewController *vc = [self.htmlAdapter valueForKey:@"htmlViewController"];
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [vc performSelector:NSSelectorFromString(@"dismissWithoutResolution")];
+# pragma clang diagnostic pop
 }
 
 - (void)refreshInbox:(CDVInvokedUrlCommand *)command {
@@ -842,40 +877,6 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     [self.commandDelegate sendPluginResult:result callbackId:self.listenerCallbackID];
 
     return true;
-}
-
-- (void)displayOverlayMessage:(UAInboxMessage *)message {
-    UA_LTRACE(@"Displaying overlay message:%@", message);
-
-    if (!self.factoryBlockAssigned) {
-        [[UAirship inAppMessageManager] setFactoryBlock:^id<UAInAppMessageAdapterProtocol> _Nonnull(UAInAppMessage * _Nonnull message) {
-            UAInAppMessageHTMLAdapter *adapter = [UAInAppMessageHTMLAdapter adapterForMessage:message];
-            UAInAppMessageHTMLDisplayContent *displayContent = (UAInAppMessageHTMLDisplayContent *) message.displayContent;
-            NSURL *url = [NSURL URLWithString:displayContent.url];
-
-            if ([url.scheme isEqualToString:@"message"]) {
-                self.htmlAdapter = adapter;
-            }
-
-            return adapter;
-        } forDisplayType:UAInAppMessageDisplayTypeHTML];
-
-        self.factoryBlockAssigned = YES;
-    }
-
-    [UAActionRunner runActionWithName:kUAOverlayInboxMessageActionDefaultRegistryName
-                                value:message.messageID
-                            situation:UASituationManualInvocation];
-}
-
-- (void)closeOverlayMessage {
-    UA_LTRACE(@"closeOverlayMessage called");
-
-    UIViewController *vc = [self.htmlAdapter valueForKey:@"htmlViewController"];
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    [vc performSelector:NSSelectorFromString(@"dismissWithoutResolution")];
-# pragma clang diagnostic pop
 }
 
 @end

--- a/src/ios/events/UACordovaShowInboxEvent.m
+++ b/src/ios/events/UACordovaShowInboxEvent.m
@@ -27,7 +27,7 @@ NSString *const EventShowInbox = @"urbanairship.show_inbox";
     self = [super init];
     if (self) {
         self.type = EventShowInbox;
-        self.data = @{@"messageId":identifier};
+        self.data = identifier ? @{@"messageId":identifier} : @{};
     }
 
     return self;


### PR DESCRIPTION
This is mostly updating the plugin and podspec versions, with a few fixes for the deprecation warnings that come with the push -> channel refactor, as well as some iOS 13 stuff. I also had to bump the minimum SDK version of the sample to 11.0 so that the SDK pod would install properly. 

While I was looking, I also cleaned up a variety of compiler and analyzer warnings such as:

* missing nullability annotations
* dictionary values that might be accidentally nil (which would cause crashes)
* the overlay inbox message method, which was accidentally recursing into itself instead of calling its helper

Manual testing is in progress but no surprises so far.

Note: because of the current CI issues, and because it would be a gnarly rebase otherwise, I'm temporarily setting this up to merge into the the event data refactor branch, which should go out with this update.