### PR TITLE
[MOBILE-1142] Add cordova plugin version tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "Urban Airship Cordova plugin",
   "cordova": {
     "id": "urbanairship-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin id="urbanairship-cordova"
-        version="9.0.1"
+        version="10.0.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -34,6 +34,10 @@
         </config-file>
 
         <config-file parent="/manifest/application" target="AndroidManifest.xml">
+            <meta-data
+                android:name="com.urbanairship.cordova.version"
+                android:value="10.0.0"/>
+
             <meta-data
                 android:name="com.urbanairship.autopilot"
                 android:value="com.urbanairship.cordova.CordovaAutopilot"/>
@@ -119,7 +123,6 @@
             src="src/android/events/Event.java"
             target-dir="src/com/urbanairship/cordova/events"/>
 
-
         <framework
             custom="true"
             src="src/android/build-extras.gradle"
@@ -135,6 +138,10 @@
             <array>
                 <string>remote-notification</string>
             </array>
+        </config-file>
+
+        <config-file target="*-Info.plist" parent="UACordovaPluginVersion">
+            <string>10.0.0</string>
         </config-file>
 
         <config-file parent="/widget" target="config.xml">

--- a/src/ios/UACordovaPluginManager.m
+++ b/src/ios/UACordovaPluginManager.m
@@ -34,8 +34,9 @@ NSString *const NotificationPresentationAlertKey = @"com.urbanairship.ios_foregr
 NSString *const NotificationPresentationBadgeKey = @"com.urbanairship.ios_foreground_notification_presentation_badge";
 NSString *const NotificationPresentationSoundKey = @"com.urbanairship.ios_foreground_notification_presentation_sound";
 NSString *const CloudSiteConfigKey = @"com.urbanairship.site";
-
 NSString *const CloudSiteEUString = @"EU";
+
+NSString *const UACordovaPluginVersionKey = @"UACordovaPluginVersion";
 
 // Events
 NSString *const CategoriesPlistPath = @"UACustomNotificationCategories";
@@ -82,6 +83,7 @@ NSString *const CategoriesPlistPath = @"UACustomNotificationCategories";
     }
 
     [UAirship takeOff:config];
+    [self registerCordovaPluginVersion];
 
     [UAirship push].userPushNotificationsEnabledByDefault = [[self configValueForKey:EnablePushOnLaunchConfigKey] boolValue];
 
@@ -152,6 +154,11 @@ NSString *const CategoriesPlistPath = @"UACustomNotificationCategories";
     }
 
     return airshipConfig;
+}
+
+- (void)registerCordovaPluginVersion {
+    NSString *version = [NSBundle mainBundle].infoDictionary[UACordovaPluginVersionKey] ?: @"0.0.0";
+    [[UAirship analytics] registerSDKExtension:UASDKExtensionCordova version:version];
 }
 
 - (id)configValueForKey:(NSString *)key {

--- a/update_version.sh
+++ b/update_version.sh
@@ -11,4 +11,6 @@ fi
 sed -i '' "s/\version\": \".*\",/\version\": \"$VERSION\",/g" package.json
 
 # Updates the urbanairship-cordova version in plugin.xml
-sed -i '' "s/\version=\".*\">/\version=\"$VERSION\">/g" plugin.xml
+sed -E -i '' "s/\version=\"[0-9]+\.[0-9]+\.[0-9]+.*\"/\version=\"$VERSION\"/g" plugin.xml
+sed -E -i '' "s/\android:value=\"[0-9]+\.[0-9]+\.[0-9]+.*\"/\android:value=\"$VERSION\"/g" plugin.xml
+sed -E -i '' "s/\<string>[0-9]+\.[0-9]+\.[0-9]+.*<\/string>/\<string>$VERSION<\/string>/g" plugin.xml


### PR DESCRIPTION
### What do these changes do?
Adds cordova plugin tracking so we can tell people use cordova. I made it so the version is supplied through the plugin.xml in either the Info.plist or as metadata in the manifest. Then the plugins will pull from the right place and track the extension. "0.0.0" is the default value if the version is unavailable for whatever reason.

### Why are these changes necessary?
Helps us identify what versions of cordova plugin are in the wild.

### How did you verify these changes?
Manually tested it.
