### PR TITLE
[MOBILE-1290] Add screen tracking

### DIFF
--- a/Example/index.html
+++ b/Example/index.html
@@ -55,11 +55,11 @@
         document.addEventListener("urbanairship.push", onPushReceived, false)
         document.addEventListener("urbanairship.notification_opened", notificationOpened, false)
         document.addEventListener("urbanairship.deep_link", handleDeepLink, false)
-        
+
         // Handle resume
         document.addEventListener("resume", function() {
           console.log("Device resume!")
-          
+
           UAirship.resetBadge()
 
           // Reregister for urbanairship events if they were removed in pause event
@@ -70,7 +70,7 @@
         // Handle pause
         document.addEventListener("pause", function() {
           console.log("Device pause!")
-         
+
           // Remove urbanairship events.  Important on android to not receive push in the background.
           document.removeEventListener("urbanairship.registration", onRegistration, false)
           document.removeEventListener("urbanairship.push", onPushReceived, false)
@@ -78,7 +78,7 @@
 
         // Initiate the UI
         initiateUI()
-        
+
         // Get the launch notification if its available.
       }
 
@@ -162,6 +162,7 @@
         $("#displayMessageCenterButton").click(function(ev) {
           console.log("Displaying Message Center")
           UAirship.displayMessageCenter()
+          UAirship.trackScreen("Message Center")
 
           })
 

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -1089,8 +1089,8 @@ public class UAirshipPlugin extends CordovaPlugin {
      * @param callbackContext The callback context.
      */
     void trackScreen(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
-        String screen = data.getBoolean(0);
-        UAirship.shared().analytics.trackScreen(screen);
+        String screen = data.getString(0);
+        UAirship.shared().getAnalytics().trackScreen(screen);
         callbackContext.success();
     }
 }

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -73,7 +73,7 @@ public class UAirshipPlugin extends CordovaPlugin {
             "setNamedUser", "getNamedUser", "runAction", "editNamedUserTagGroups", "editChannelTagGroups", "displayMessageCenter", "markInboxMessageRead",
             "deleteInboxMessage", "getInboxMessages", "displayInboxMessage", "refreshInbox", "getDeepLink", "setAssociatedIdentifier",
             "isAppNotificationsEnabled", "dismissMessageCenter", "dismissInboxMessage", "setAutoLaunchDefaultMessageCenter",
-            "getActiveNotifications", "clearNotification", "editChannelAttributes");
+            "getActiveNotifications", "clearNotification", "editChannelAttributes", "trackScreen");
 
 
     /*

--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -1079,4 +1079,18 @@ public class UAirshipPlugin extends CordovaPlugin {
         editor.apply();
         callbackContext.success();
     }
+
+    /**
+     * Initiates screen tracking for a specific app screen.
+     * <p/>
+     * Expected arguments: String
+     *
+     * @param data The call data.
+     * @param callbackContext The callback context.
+     */
+    void trackScreen(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
+        String screen = data.getBoolean(0);
+        UAirship.shared().analytics.trackScreen(screen);
+        callbackContext.success();
+    }
 }

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -553,6 +553,19 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     }];
 }
 
+- (void)trackScreen:(CDVInvokedUrlCommand *)command {
+    UA_LTRACE("trackScreen called with command arguments: %@", command.arguments);
+
+    [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
+        NSString *screen = [args objectAtIndex:0];
+
+        UA_LTRACE("trackScreen set to:%@", screen);
+
+        [[UAirship analytics] trackScreen:screen];
+
+        completionHandler(CDVCommandStatus_OK, nil);
+    }];
+}
 - (void)runAction:(CDVInvokedUrlCommand *)command {
     UA_LTRACE("runAction called with command arguments: %@", command.arguments);
 

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -965,5 +965,18 @@ module.exports = {
     }
 
     _runAction("add_custom_event_action", actionArg, success, failure)
+  },
+
+  /**
+   * Initiates screen tracking for a specific app screen, must be called once per tracked screen.
+   *
+   * @param {string} screen The screen's string identifier.
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   */
+  trackScreen: function(screen, success, failure) {
+    argscheck.checkArgs('*FF', 'UAirship.trackScreen', arguments)
+    callNative(success, failure, "trackScreen", [screen])
   }
 }

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -976,7 +976,7 @@ module.exports = {
    * @param {string} failure.message The error message.
    */
   trackScreen: function(screen, success, failure) {
-    argscheck.checkArgs('*FF', 'UAirship.trackScreen', arguments)
+    argscheck.checkArgs('sFF', 'UAirship.trackScreen', arguments)
     callNative(success, failure, "trackScreen", [screen])
   }
 }


### PR DESCRIPTION
### What do these changes do?
Add screen tracking to Cordova

### How did you verify these changes?
Manual tests, verified that the method is called on iOS and Android 

#### Verification Screenshots:
<img width="541" alt="Capture d’écran 2020-02-17 à 15 51 02" src="https://user-images.githubusercontent.com/16866668/74664149-77cf2180-519d-11ea-9cc2-44050d2aee51.png">

