### PR TITLE
[MOBILE-1344] Add plugin version check to CI

### DIFF
--- a/scripts/check_plugin_version.sh
+++ b/scripts/check_plugin_version.sh
@@ -9,20 +9,32 @@ packageJSONFilePath="$ROOT_PATH/package.json"
 packageJSONVersionRegex='"version": ?"[0-9]+\.[0-9]+\.[0-9]+"'
 packageJSONVersion=$(grep -E "$packageJSONVersionRegex" $packageJSONFilePath | cut -f4 -d \")
 
-
 # Get version from plugin.xml file
 pluginXMLFilePath="$ROOT_PATH/plugin.xml"
+
 # Get plugin version
 pluginXMLFileVersionRegex='version= ?"[0-9]+\.[0-9]+\.[0-9]+"'
 pluginXMLFileVersion=$(grep -E "$pluginXMLFileVersionRegex" $pluginXMLFilePath | cut -f2 -d \")
+
+if [ "$pluginXMLFileVersion" != "$packageJSONVersion" ]; then
+	echo "BUILD FAILED: The plugin version is not correct in the plugin.xml file. The version should be the same than the one in the package.json file."
+	exit 1
+fi
+
 # Get plugin version for android config
 pluginXMLAndroidConfigVersionRegex='android:value= ?"[0-9]+\.[0-9]+\.[0-9]+"'
 pluginXMLAndroidConfigVersion=$(grep -E "$pluginXMLAndroidConfigVersionRegex" $pluginXMLFilePath | cut -f2 -d \")
+
+if [ "$pluginXMLAndroidConfigVersion" != "$packageJSONVersion" ]; then
+	echo "BUILD FAILED: The plugin version in the Android Config is not correct in the plugin.xml file. The version should be the same than the one in the package.json file."
+	exit 1
+fi
+
 # Get plugin version for iOS config
 pluginXMLiOSConfigVersionRegex='<string>[0-9]+\.[0-9]+\.[0-9]+'
 pluginXMLiOSConfigVersion=$(grep -E "$pluginXMLiOSConfigVersionRegex" $pluginXMLFilePath | cut -f2 -d \> | cut -f1 -d \<)
 
-if [ "$pluginXMLFileVersion" != "$packageJSONVersion" ] || [ "$pluginXMLAndroidConfigVersion" != "$packageJSONVersion" ] || [ "$pluginXMLiOSConfigVersion" != "$packageJSONVersion" ]; then
-	echo "BUILD FAILED: The plugin version is not the same everywhere (please check package.json and plugin.xml files)"
+if [ "$pluginXMLiOSConfigVersion" != "$packageJSONVersion" ]; then
+	echo "BUILD FAILED: The plugin version in the iOS Config is not correct in the plugin.xml file. The version should be the same than the one in the package.json file."
 	exit 1
 fi

--- a/scripts/check_plugin_version.sh
+++ b/scripts/check_plugin_version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+set -x
+
+ROOT_PATH=`dirname "${0}"`/..
+
+# Get version from package.json file
+packageJSONFilePath="$ROOT_PATH/package.json"
+packageJSONVersionRegex='"version": ?"[0-9]+\.[0-9]+\.[0-9]+"'
+packageJSONVersion=$(grep -E "$packageJSONVersionRegex" $packageJSONFilePath | cut -f4 -d \")
+
+
+# Get version from plugin.xml file
+pluginXMLFilePath="$ROOT_PATH/plugin.xml"
+# Get plugin version
+pluginXMLFileVersionRegex='version= ?"[0-9]+\.[0-9]+\.[0-9]+"'
+pluginXMLFileVersion=$(grep -E "$pluginXMLFileVersionRegex" $pluginXMLFilePath | cut -f2 -d \")
+# Get plugin version for android config
+pluginXMLAndroidConfigVersionRegex='android:value= ?"[0-9]+\.[0-9]+\.[0-9]+"'
+pluginXMLAndroidConfigVersion=$(grep -E "$pluginXMLAndroidConfigVersionRegex" $pluginXMLFilePath | cut -f2 -d \")
+# Get plugin version for iOS config
+pluginXMLiOSConfigVersionRegex='<string>[0-9]+\.[0-9]+\.[0-9]+'
+pluginXMLiOSConfigVersion=$(grep -E "$pluginXMLiOSConfigVersionRegex" $pluginXMLFilePath | cut -f2 -d \> | cut -f1 -d \<)
+
+if [ "$pluginXMLFileVersion" != "$packageJSONVersion" ] || [ "$pluginXMLAndroidConfigVersion" != "$packageJSONVersion" ] || [ "$pluginXMLiOSConfigVersion" != "$packageJSONVersion" ]; then
+	echo "BUILD FAILED: The plugin version is not the same everywhere (please check package.json and plugin.xml files)"
+	exit 1
+fi

--- a/scripts/check_plugin_version.sh
+++ b/scripts/check_plugin_version.sh
@@ -17,7 +17,7 @@ pluginXMLFileVersionRegex='version= ?"[0-9]+\.[0-9]+\.[0-9]+"'
 pluginXMLFileVersion=$(grep -E "$pluginXMLFileVersionRegex" $pluginXMLFilePath | cut -f2 -d \")
 
 if [ "$pluginXMLFileVersion" != "$packageJSONVersion" ]; then
-	echo "BUILD FAILED: The plugin version is not correct in the plugin.xml file. The version should be the same than the one in the package.json file."
+	echo "BUILD FAILED: The plugin version is not correct in the plugin.xml file. The version should be the same as the one in the package.json file."
 	exit 1
 fi
 
@@ -26,7 +26,7 @@ pluginXMLAndroidConfigVersionRegex='android:value= ?"[0-9]+\.[0-9]+\.[0-9]+"'
 pluginXMLAndroidConfigVersion=$(grep -E "$pluginXMLAndroidConfigVersionRegex" $pluginXMLFilePath | cut -f2 -d \")
 
 if [ "$pluginXMLAndroidConfigVersion" != "$packageJSONVersion" ]; then
-	echo "BUILD FAILED: The plugin version in the Android Config is not correct in the plugin.xml file. The version should be the same than the one in the package.json file."
+	echo "BUILD FAILED: The plugin version in the Android Config is not correct in the plugin.xml file. The version should be the same as the one in the package.json file."
 	exit 1
 fi
 
@@ -35,6 +35,6 @@ pluginXMLiOSConfigVersionRegex='<string>[0-9]+\.[0-9]+\.[0-9]+'
 pluginXMLiOSConfigVersion=$(grep -E "$pluginXMLiOSConfigVersionRegex" $pluginXMLFilePath | cut -f2 -d \> | cut -f1 -d \<)
 
 if [ "$pluginXMLiOSConfigVersion" != "$packageJSONVersion" ]; then
-	echo "BUILD FAILED: The plugin version in the iOS Config is not correct in the plugin.xml file. The version should be the same than the one in the package.json file."
+	echo "BUILD FAILED: The plugin version in the iOS Config is not correct in the plugin.xml file. The version should be the same as the one in the package.json file."
 	exit 1
 fi

--- a/scripts/run_ci_tasks.sh
+++ b/scripts/run_ci_tasks.sh
@@ -39,6 +39,10 @@ while true; do
   shift
 done
 
+# ckeck for version
+${SCRIPT_DIRECTORY}/check_plugin_version.sh
+
+
 SAMPLE_APP_PATH=${1:-}
 
 if [ "$ANDROID" = "true" ] || [ "$IOS" = "true" ]; then

--- a/scripts/run_ci_tasks.sh
+++ b/scripts/run_ci_tasks.sh
@@ -42,7 +42,6 @@ done
 # ckeck for version
 ${SCRIPT_DIRECTORY}/check_plugin_version.sh
 
-
 SAMPLE_APP_PATH=${1:-}
 
 if [ "$ANDROID" = "true" ] || [ "$IOS" = "true" ]; then


### PR DESCRIPTION
### What do these changes do?
Add plugin version check to cordova CI

### Why are these changes necessary?
Because we have 4 different places where we have to version our cordova plugin and it will be safer to have this check in the CI

### How did you verify these changes?
By testing it manually with the CI script.

#### Verification Screenshots:
<img width="835" alt="Capture d’écran 2020-03-16 à 12 09 07" src="https://user-images.githubusercontent.com/24393953/76750679-f7d9ae80-677e-11ea-90ed-36c71c91444c.png">

### Anything else a reviewer should know?
The script can be used outside of the CI too.
