### PR TITLE
[MOBILE-1505] Update iOS SDK to 13.3.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -192,7 +192,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="Airship" spec="13.1.1" />
+                <pod name="Airship" spec="13.3.0" />
             </pods>
         </podspec>
 

--- a/src/ios/UACordovaPluginManager.h
+++ b/src/ios/UACordovaPluginManager.h
@@ -2,12 +2,10 @@
 
 #import <Foundation/Foundation.h>
 
-#if __has_include(<Airship/AirshipLib.h>)
-#import <Airship/AirshipLib.h>
-#elif __has_include("AirshipLib.h")
+#if __has_include("AirshipLib.h")
 #import "AirshipLib.h"
 #else
-@import AirshipKit;
+@import Airship;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/ios/UAMessageViewController.h
+++ b/src/ios/UAMessageViewController.h
@@ -7,7 +7,9 @@
 @import Airship;
 #endif
 
-@interface UAMessageViewController : UAMessageCenterMessageViewController
+@interface UAMessageViewController : UINavigationController
+
+- (void)loadMessageForID:(nullable NSString *)messageID;
 
 @end
 

--- a/src/ios/UAMessageViewController.m
+++ b/src/ios/UAMessageViewController.m
@@ -2,26 +2,164 @@
 
 #import "UAMessageViewController.h"
 
+@interface UAMessageViewController() <UAMessageCenterMessageViewDelegate>
+@property (nonatomic, copy) NSString *pendingMessageID;
+@property (nonatomic, strong) UADefaultMessageCenterMessageViewController *airshipMessageViewController;
+@end
+
 @implementation UAMessageViewController
 
 - (void) viewDidLoad {
     [super viewDidLoad];
+
+    self.airshipMessageViewController = [[UADefaultMessageCenterMessageViewController alloc]
+                                         initWithNibName:@"UADefaultMessageCenterMessageViewController"
+                                         bundle:[UAMessageCenterResources bundle]];
+    self.airshipMessageViewController.delegate = self;
+
 
     UIBarButtonItem *done = [[UIBarButtonItem alloc]
                              initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                              target:self
                              action:@selector(inboxMessageDone:)];
 
-    self.navigationItem.rightBarButtonItem = done;
+    self.airshipMessageViewController.navigationItem.leftBarButtonItem = done;
 
-     __weak UAMessageViewController *weakSelf = self;
-    self.closeBlock = ^(BOOL animated) {
-        [weakSelf dismissViewControllerAnimated:animated completion:nil];
-    };
+    self.viewControllers = @[self.airshipMessageViewController];
+
+    if (self.pendingMessageID) {
+        [self.airshipMessageViewController loadMessageForID:self.pendingMessageID];
+        self.pendingMessageID = nil;
+    }
 }
 
 - (void)inboxMessageDone:(id)sender {
     [self dismissViewControllerAnimated:true completion:nil];
 }
 
+- (void)loadMessageForID:(NSString *)messageID {
+    if (self.airshipMessageViewController) {
+        [self.airshipMessageViewController loadMessageForID:messageID];
+        self.pendingMessageID = nil;
+    } else {
+        self.pendingMessageID = messageID;
+    }
+}
+
+#pragma mark UAMessageCenterMessageViewDelegate
+
+- (void)messageClosed:(NSString *)messageID {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)messageLoadStarted:(NSString *)messageID {
+    // no-op
+}
+
+- (void)messageLoadSucceeded:(NSString *)messageID {
+    // no-op
+}
+
+- (void)displayFailedToLoadAlertOnOK:(void (^)(void))okCompletion onRetry:(void (^)(void))retryCompletion {
+    UIAlertController* alert = [UIAlertController alertControllerWithTitle:UAMessageCenterLocalizedString(@"ua_connection_error")
+                                                                   message:UAMessageCenterLocalizedString(@"ua_mc_failed_to_load")
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:UAMessageCenterLocalizedString(@"ua_ok")
+                                                            style:UIAlertActionStyleDefault
+                                                          handler:^(UIAlertAction * action) {
+        if (okCompletion) {
+            okCompletion();
+        }
+    }];
+
+    [alert addAction:defaultAction];
+
+    if (retryCompletion) {
+        UIAlertAction *retryAction = [UIAlertAction actionWithTitle:UAMessageCenterLocalizedString(@"ua_retry_button")
+                                                              style:UIAlertActionStyleDefault
+                                                            handler:^(UIAlertAction * _Nonnull action) {
+            if (retryCompletion) {
+                retryCompletion();
+            }
+        }];
+
+        [alert addAction:retryAction];
+    }
+
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)displayNoLongerAvailableAlertOnOK:(void (^)(void))okCompletion {
+    UIAlertController* alert = [UIAlertController alertControllerWithTitle:UAMessageCenterLocalizedString(@"ua_content_error")
+                                                                   message:UAMessageCenterLocalizedString(@"ua_mc_no_longer_available")
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:UAMessageCenterLocalizedString(@"ua_ok")
+                                                            style:UIAlertActionStyleDefault
+                                                          handler:^(UIAlertAction * action) {
+        if (okCompletion) {
+            okCompletion();
+        }
+    }];
+
+    [alert addAction:defaultAction];
+
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)messageLoadFailed:(NSString *)messageID error:(NSError *)error {
+    UA_LTRACE(@"message load failed: %@", messageID);
+
+    void (^retry)(void) = ^{
+        UA_WEAKIFY(self);
+        [self displayFailedToLoadAlertOnOK:^{
+            UA_STRONGIFY(self)
+            [self dismissViewControllerAnimated:true completion:nil];
+        } onRetry:^{
+            UA_STRONGIFY(self)
+            [self loadMessageForID:messageID];
+        }];
+    };
+
+    void (^handleFailed)(void) = ^{
+        UA_WEAKIFY(self);
+        [self displayFailedToLoadAlertOnOK:^{
+            UA_STRONGIFY(self)
+            [self dismissViewControllerAnimated:true completion:nil];
+        } onRetry:nil];
+    };
+
+    void (^handleExpired)(void) = ^{
+        UA_WEAKIFY(self);
+        [self displayNoLongerAvailableAlertOnOK:^{
+            UA_STRONGIFY(self)
+            [self dismissViewControllerAnimated:true completion:nil];
+        }];
+    };
+
+    if ([error.domain isEqualToString:UAMessageCenterMessageLoadErrorDomain]) {
+        if (error.code == UAMessageCenterMessageLoadErrorCodeFailureStatus) {
+            // Encountered a failure status code
+            NSUInteger status = [error.userInfo[UAMessageCenterMessageLoadErrorHTTPStatusKey] unsignedIntValue];
+
+            if (status >= 500) {
+                retry();
+            } else if (status == 410) {
+                // Gone: message has been permanently deleted from the backend.
+                handleExpired();
+            } else {
+                handleFailed();
+            }
+        } else if (error.code == UAMessageCenterMessageLoadErrorCodeMessageExpired) {
+            handleExpired();
+        } else {
+            retry();
+        }
+    } else {
+        // Other errors
+        retry();
+    }
+}
 @end
+


### PR DESCRIPTION
### What do these changes do?
Updates iOS SDK to 13.3.0. The biggest change is the message view deprecations. I copied most the changes from DefaultSplitViewController. There are few things we could do to make it easier to implement without as much duplicate code in the future, like maybe an MessageViewErrorHandler.

### Why are these changes necessary?
Updates latest iOS SDK. 

### How did you verify these changes?
Ran sample on both iOS 11 and 13 simulators.

#### Verification Screenshots:
![Simulator Screen Shot - iPhone 8 - 2020-05-05 at 09 29 57](https://user-images.githubusercontent.com/3967591/81090792-1886d080-8eb3-11ea-81ef-32ea259bb1df.png)

