### PR TITLE
[MOBILE-1566] Add named user attributes

### DIFF
--- a/src/android/UAirshipPlugin.java
+++ b/src/android/UAirshipPlugin.java
@@ -72,7 +72,7 @@ public class UAirshipPlugin extends CordovaPlugin {
             "setNamedUser", "getNamedUser", "runAction", "editNamedUserTagGroups", "editChannelTagGroups", "displayMessageCenter", "markInboxMessageRead",
             "deleteInboxMessage", "getInboxMessages", "displayInboxMessage", "refreshInbox", "getDeepLink", "setAssociatedIdentifier",
             "isAppNotificationsEnabled", "dismissMessageCenter", "dismissInboxMessage", "setAutoLaunchDefaultMessageCenter",
-            "getActiveNotifications", "clearNotification", "editChannelAttributes", "trackScreen", "setDataCollectionEnabled", "isDataCollectionEnabled",
+            "getActiveNotifications", "clearNotification", "editChannelAttributes", "editNamedUserAttributes", "trackScreen", "setDataCollectionEnabled", "isDataCollectionEnabled",
             "setPushTokenRegistrationEnabled", "isPushTokenRegistrationEnabled");
 
     /*
@@ -161,6 +161,8 @@ public class UAirshipPlugin extends CordovaPlugin {
                         displayMessageCenter(data, callbackContext);
                     } else if ("editChannelAttributes".equals(action)) {
                         editChannelAttributes(data, callbackContext);
+                    } else if ("editNamedUserAttributes".equals(action)) {
+                        editNamedUserAttributes(data, callbackContext);
                     } else if ("editChannelTagGroups".equals(action)) {
                         editChannelTagGroups(data, callbackContext);
                     } else if ("editNamedUserTagGroups".equals(action)) {
@@ -1151,9 +1153,41 @@ public class UAirshipPlugin extends CordovaPlugin {
      */
     private void editChannelAttributes(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
         JSONArray operations = data.getJSONArray(0);
+
         PluginLogger.debug("Editing channel attributes: %s", operations);
 
         AttributeEditor editor = UAirship.shared().getChannel().editAttributes();
+        applyAttributesOperations(editor, operations);
+        editor.apply();
+
+        callbackContext.success();
+    }
+
+    /**
+     * Edits the named user attributes.
+     *
+     * @param data The call data.
+     * @param callbackContext The callback context.
+     */
+    private void editNamedUserAttributes(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
+        JSONArray operations = data.getJSONArray(0);
+
+        PluginLogger.debug("Editing named user attributes: %s", operations);
+
+        AttributeEditor editor = UAirship.shared().getNamedUser().editAttributes();
+        applyAttributesOperations(editor, operations);
+        editor.apply();
+
+        callbackContext.success();
+    }
+
+    /**
+     * Helper method to apply attribute operations to an AttributeEditor.
+     *
+     * @param editor The attribute editor.
+     * @param operations The attribute operations.
+     */
+    private static void applyAttributesOperations(AttributeEditor editor, JSONArray operations) throws JSONException {
         for (int i = 0; i < operations.length(); i++) {
             JSONObject operation = operations.optJSONObject(i);
             if (operation == null) {
@@ -1180,9 +1214,6 @@ public class UAirshipPlugin extends CordovaPlugin {
                 editor.removeAttribute(key);
             }
         }
-
-        editor.apply();
-        callbackContext.success();
     }
 
     /**

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -304,7 +304,7 @@
  *
  * @param operations The attribute operations.
  */
-- (UAAttributeMutations)mutationsWithOperations:(NSArray *)operations;
+- (UAAttributeMutations *)mutationsWithOperations:(NSArray *)operations;
 
 /**
  * Registers a listener for events.

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -282,6 +282,31 @@
 - (void)editChannelAttributes:(CDVInvokedUrlCommand *)command;
 
 /**
+ * Edits the named user attributes.
+ *
+ * Expected arguments: An array of objects that contain:
+ * "action": String, either `remove` or `set`
+ * "key": String, the attribute name.
+ * "value": String, the attribute value.
+ *
+ * @param command The cordova command.
+ */
+- (void)editNamedUserAttributes:(CDVInvokedUrlCommand *)command;
+
+
+/**
+ * Helper method to prepare attribute mutation object from attribute operations.
+ *
+ * Expected arguments: An array of objects that contain:
+ * "action": String, either `remove` or `set`
+ * "key": String, the attribute name.
+ * "value": String, the attribute value.
+ *
+ * @param operations The attribute operations.
+ */
+- (UAAttributeMutations)mutationsWithOperations:(NSArray *)operations;
+
+/**
  * Registers a listener for events.
  *
  * @param command The cordova command.

--- a/src/ios/UAirshipPlugin.h
+++ b/src/ios/UAirshipPlugin.h
@@ -293,19 +293,6 @@
  */
 - (void)editNamedUserAttributes:(CDVInvokedUrlCommand *)command;
 
-
-/**
- * Helper method to prepare attribute mutation object from attribute operations.
- *
- * Expected arguments: An array of objects that contain:
- * "action": String, either `remove` or `set`
- * "key": String, the attribute name.
- * "value": String, the attribute value.
- *
- * @param operations The attribute operations.
- */
-- (UAAttributeMutations *)mutationsWithOperations:(NSArray *)operations;
-
 /**
  * Registers a listener for events.
  *

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -825,6 +825,16 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     }];
 }
 
+/**
+ * Helper method to prepare attribute mutation object from attribute operations.
+ *
+ * Expected arguments: An array of objects that contain:
+ * "action": String, either `remove` or `set`
+ * "key": String, the attribute name.
+ * "value": String, the attribute value.
+ *
+ * @param operations The attribute operations.
+ */
 - (UAAttributeMutations *) mutationsWithOperations:(NSArray *)operations {
     UAAttributeMutations *mutations = [UAAttributeMutations mutations];
 

--- a/src/ios/UAirshipPlugin.m
+++ b/src/ios/UAirshipPlugin.m
@@ -821,14 +821,14 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
 
     [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
         UAAttributeMutations *mutations = [self mutationsWithOperations:args];
-        [[UAirship channel] applyAttributeMutations:mutations];
+        [[UAirship namedUser] applyAttributeMutations:mutations];
     }];
 }
 
-- (UAAttributeMutations) mutationsWithOperations:(NSArray *)operations {
+- (UAAttributeMutations *) mutationsWithOperations:(NSArray *)operations {
     UAAttributeMutations *mutations = [UAAttributeMutations mutations];
 
-    for (NSDictionary *operation in [args objectAtIndex:0]) {
+    for (NSDictionary *operation in [operations objectAtIndex:0]) {
         NSString *action = operation[@"action"];
         NSString *name = operation[@"key"];
 

--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -643,6 +643,15 @@ module.exports = {
   },
 
   /**
+   * Creates an editor to modify the named user attributes.
+   *
+   * @return {AttributesEditor} An attributes editor instance.
+   */
+  editNamedUserAttributes: function() {
+    return new AttributesEditor('editNamedUserAttributes')
+  },
+
+  /**
    * Sets an associated identifier for the Connect data stream.
    *
    * @param {string} Custom key for identifier.


### PR DESCRIPTION
### What do these changes do?
Adds a method to edit named user attributes

### Why are these changes necessary?
To keep the cordova plugin up to date with the native features

### How did you verify these changes?
In the logs

#### Verification Screenshots:
```
2020-05-27 15:59:49.352 3191-3395/com.urbanairship.sample D/UALib-Cordova: Plugin Execute: editNamedUserAttributes
2020-05-27 15:59:49.352 3191-3395/com.urbanairship.sample D/UALib-Cordova: Editing named user attributes: [{"action":"set","value":"Rico","key":"nickname","type":"string"}]
2020-05-27 15:59:49.353 3191-4868/com.urbanairship.sample V/Test - UALib: PreferenceDataStore - Saving preference: com.urbanairship.nameduser.ATTRIBUTE_MUTATION_STORE_KEY value: [[{"timestamp":"2020-05-27T14:19:44","value":"Ulrich's phone","key":"device_name","action":"set"}],[{"timestamp":"2020-05-27T18:30:16","value":"Ulrich's phone","key":"device_name","action":"set"}],[{"timestamp":"2020-05-27T19:59:49","value":"Rico","key":"nickname","action":"set"}]]
2020-05-27 15:59:49.360 3191-3191/com.urbanairship.sample V/Test - UALib: AirshipService - Received intent: Intent { act=RUN_JOB cmp=com.urbanairship.sample/com.urbanairship.job.AirshipService (has extras) }
2020-05-27 15:59:49.361 3191-4996/com.urbanairship.sample V/Test - UALib: AirshipService - Running job: JobInfo{action=ACTION_UPDATE_NAMED_USER, id=2, extras='{}', airshipComponentName='com.urbanairship.channel.NamedUser', isNetworkAccessRequired=true, initialDelay=0, persistent=false}
2020-05-27 15:59:49.361 3191-4869/com.urbanairship.sample V/Test - UALib: Job - Finished: JobInfo{action=ACTION_UPDATE_NAMED_USER, id=2, extras='{}', airshipComponentName='com.urbanairship.channel.NamedUser', isNetworkAccessRequired=true, initialDelay=0, persistent=false} with result: 0
2020-05-27 15:59:49.361 3191-4996/com.urbanairship.sample V/Test - UALib: AirshipService - Component finished job with startId: 1
2020-05-27 15:59:49.361 3191-4996/com.urbanairship.sample V/Test - UALib: AirshipService - All jobs finished, stopping with last startId: 1
```

<img width="581" alt="Capture d’écran 2020-05-27 à 15 53 32" src="https://user-images.githubusercontent.com/24393953/83066090-cde91600-a064-11ea-8a22-5638d250f049.png">
