### PR TITLE
FIX cordova spelling

### DIFF
--- a/www/UrbanAirship.js
+++ b/www/UrbanAirship.js
@@ -1,6 +1,6 @@
 /* Copyright Urban Airship and Contributors */
 
-var cardova = require("cordova"),
+var cordova = require("cordova"),
     exec = require("cordova/exec"),
     argscheck = require('cordova/argscheck')
 


### PR DESCRIPTION
I've noticed this 'cordova' was misspelled 'cardova' in this file.

It seems that it is then been used at the following line:
`cordova.fireDocumentEvent(e.eventType, e.eventData)`