### PR TITLE
Fix jsdoc out path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
       - name: Upload docs
-        run: bash ./scripts/upload_docs.sh ${GITHUB_REF/refs\/tags\//} out
+        run: bash ./scripts/upload_docs.sh ${GITHUB_REF/refs\/tags\//} jsdoc_out
       - name: Publish modules
         run: |
           cd urbanairship-cordova/

--- a/urbanairship-cordova/package.json
+++ b/urbanairship-cordova/package.json
@@ -49,6 +49,6 @@
     "superagent": "^4.1.0"
   },
   "scripts": {
-    "generate-docs": "jsdoc ./www/UrbanAirship.js -t ../node_modules/minami/ -r ../jsdoc_readme.md"
+    "generate-docs": "jsdoc ./www/UrbanAirship.js -t ../node_modules/minami/ -r ../jsdoc_readme.md -d ../jsdoc_out"
   }
 }


### PR DESCRIPTION
### What do these changes do?
This fixes jsdoc output path in order to the upload_docs script to work.
I think that error comes from the merge of all our cordova repositories.

### Why are these changes necessary?
To make the upload_docs script work again and finally release cordova

### How did you verify these changes?
Just generating the docs in local

#### Verification Screenshots:

### Anything else a reviewer should know?
