### PR TITLE
[MOBILE-2438] Update setup-cloud action in release workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -9,6 +9,11 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
     steps:
       - uses: actions/checkout@v1
+        # Build tools 31.0.0 doesn't include dx (only d8), which Cordova expects to find.
+        # Uninstalling causes automatic build-tools resolution to fall back to an older
+        # version that does include dx.
+      - name: Workaround "Build-tool 31.0.0 is missing DX" error
+        run: bash $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0' 
       - name: Run CI
         run: bash ./scripts/run_ci_tasks.sh -a
   ios:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,9 +59,9 @@ jobs:
         run: |
           yarn install
           yarn generate-docs
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba # v0.2.1
         with:
-          version: "270.0.0"
+          version: '351.0.0'
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
       - name: Upload docs


### PR DESCRIPTION
### What do these changes do?

Updates to the new modular GCP setup action.

Edit: also added a workaround for `dx` not being included in `build-tools:31.0.0`, which was causing the Android CI job to fail.

### Why are these changes necessary?

So that deploys continue working.

### How did you verify these changes?

Doing it live, but tested the new action in a private repo and it installed the GCP CLI utils without issue.