### PR TITLE
[MOBILE-2679] Update sdk version and fix notification response crash

### DIFF
--- a/urbanairship-accengage-cordova/plugin.xml
+++ b/urbanairship-accengage-cordova/plugin.xml
@@ -31,7 +31,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="Airship/Accengage" spec="16.0.2" />
+                <pod name="Airship/Accengage" spec="16.1.0" />
             </pods>
         </podspec>
 

--- a/urbanairship-accengage-cordova/src/android/build-extras.gradle
+++ b/urbanairship-accengage-cordova/src/android/build-extras.gradle
@@ -18,7 +18,7 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.urbanairship.android:urbanairship-accengage:16.0.0'
+    implementation 'com.urbanairship.android:urbanairship-accengage:16.1.0'
 }
 
 ext.cdvCompileSdkVersion = 29

--- a/urbanairship-cordova/plugin.xml
+++ b/urbanairship-cordova/plugin.xml
@@ -193,11 +193,11 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="Airship/Core" spec="16.0.2" />
-                <pod name="Airship/MessageCenter" spec="16.0.2" />
-                <pod name="Airship/Automation" spec="16.0.2" />
-                <pod name="Airship/ExtendedActions" spec="16.0.2" />
-                <pod name="Airship/PreferenceCenter" spec="16.0.2" />
+                <pod name="Airship/Core" spec="16.1.0" />
+                <pod name="Airship/MessageCenter" spec="16.1.0" />
+                <pod name="Airship/Automation" spec="16.1.0" />
+                <pod name="Airship/ExtendedActions" spec="16.1.0" />
+                <pod name="Airship/PreferenceCenter" spec="16.1.0" />
             </pods>
         </podspec>
 

--- a/urbanairship-cordova/src/android/build-extras.gradle
+++ b/urbanairship-cordova/src/android/build-extras.gradle
@@ -7,7 +7,7 @@ allprojects {
 }
 
 dependencies {
-    def airshipVersion = "16.0.0"
+    def airshipVersion = "16.1.0"
     implementation "com.urbanairship.android:urbanairship-fcm:$airshipVersion"
     implementation "com.urbanairship.android:urbanairship-message-center:$airshipVersion"
     implementation "com.urbanairship.android:urbanairship-automation:$airshipVersion"

--- a/urbanairship-cordova/src/ios/events/UACordovaPushEvent.m
+++ b/urbanairship-cordova/src/ios/events/UACordovaPushEvent.m
@@ -41,18 +41,23 @@ NSString *const EventPushReceived = @"urbanairship.push";
 
         if ([[aps allKeys] containsObject:@"alert"]) {
 
-            NSDictionary *alert = aps[@"alert"];
-            if ([[alert allKeys] containsObject:@"body"]) {
-                result[@"message"] = alert[@"body"];
+            id alert = aps[@"alert"];
+            if ([alert isKindOfClass:[NSDictionary class]]) {
+                if ([[alert allKeys] containsObject:@"body"]) {
+                    result[@"message"] = alert[@"body"];
+                } else {
+                    result[@"message"] = @"";
+                }
+                if ([[alert allKeys] containsObject:@"title"]) {
+                    [result setValue:alert[@"title"] forKey:@"title"];
+                }
+                if ([[alert allKeys] containsObject:@"subtitle"]) {
+                    [result setValue:alert[@"subtitle"] forKey:@"subtitle"];
+                }
             } else {
-                result[@"message"] = @"";
+                [result setValue:alert forKey:@"message"];
             }
-            if ([[alert allKeys] containsObject:@"title"]) {
-                [result setValue:alert[@"title"] forKey:@"title"];
-            }
-            if ([[alert allKeys] containsObject:@"subtitle"]) {
-                [result setValue:alert[@"subtitle"] forKey:@"subtitle"];
-            }
+            
         }
         result[@"aps"] = info[@"aps"];
         [info removeObjectForKey:@"aps"];

--- a/urbanairship-hms-cordova/src/android/build-extras.gradle
+++ b/urbanairship-hms-cordova/src/android/build-extras.gradle
@@ -18,7 +18,7 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.urbanairship.android:urbanairship-hms:16.0.0'
+    implementation 'com.urbanairship.android:urbanairship-hms:16.1.0'
     implementation 'com.huawei.hms:push:5.1.1.301'
     implementation 'com.huawei.agconnect:agconnect-core:1.5.1.300'
 }


### PR DESCRIPTION
### What do these changes do?
Update sdk version and fix notification response crash.
Alert is not necessary a dictionary, it can be a string.

### Why are these changes necessary?
Patch for a crash.

### How did you verify these changes?
Build and run. Then test a push without any title or subtitle and verify there is no crash anymore

#### Verification Screenshots:

### Anything else a reviewer should know?

