### PR TITLE
[MOBILE-2800] fix push enabling on launch

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,7 +13,12 @@ jobs:
         # Uninstalling causes automatic build-tools resolution to fall back to an older
         # version that does include dx.
       - name: Workaround "Build-tool 31.0.0 is missing DX" error
-        run: bash $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0' 
+        run: bash $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0'
+        # Build tools 32.0.0 doesn't include dx (only d8), which Cordova expects to find.
+        # Uninstalling causes automatic build-tools resolution to fall back to an older
+        # version that does include dx.
+      - name: Workaround "Build-tool 32.0.0 is missing DX" error
+        run: bash $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;32.0.0'
       - name: Run CI
         run: bash ./scripts/run_ci_tasks.sh -a
   ios:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,11 @@ jobs:
         # version that does include dx.
       - name: Workaround "Build-tool 31.0.0 is missing DX" error
         run: bash $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0'
+        # Build tools 32.0.0 doesn't include dx (only d8), which Cordova expects to find.
+        # Uninstalling causes automatic build-tools resolution to fall back to an older
+        # version that does include dx.
+      - name: Workaround "Build-tool 32.0.0 is missing DX" error
+        run: bash $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;32.0.0'
       - name: Run CI
         run: |
           bash ./scripts/run_ci_tasks.sh -a -i

--- a/urbanairship-cordova/src/ios/UACordovaPluginManager.m
+++ b/urbanairship-cordova/src/ios/UACordovaPluginManager.m
@@ -98,7 +98,9 @@ NSString *const CategoriesPlistPath = @"UACustomNotificationCategories";
     [UAirship takeOff:config launchOptions:launchOptions];
     [self registerCordovaPluginVersion];
 
-    [UAirship push].userPushNotificationsEnabled = [[self configValueForKey:EnablePushOnLaunchConfigKey] boolValue];
+    if ([[self configValueForKey:EnablePushOnLaunchConfigKey] boolValue]) {
+        [UAirship push].userPushNotificationsEnabled = true;
+    }
 
     if ([[self configValueForKey:ClearBadgeOnLaunchConfigKey] boolValue]) {
         [[UAirship push] resetBadge];


### PR DESCRIPTION
### What do these changes do?
Set the push as enabled at launch if the config said so.

### Why are these changes necessary?
We used to set push as disabled at launch if the config enable_push_onlaunch is false.
That config field should only enable pushs at launch, not disable them.

### How did you verify these changes?
Manual tests

#### Verification Screenshots:

### Anything else a reviewer should know?
