### PR TITLE
[GH-393] Adds actions and foreground display control to Android

### DIFF
--- a/urbanairship-cordova/src/android/PluginManager.java
+++ b/urbanairship-cordova/src/android/PluginManager.java
@@ -65,7 +65,8 @@ public class PluginManager {
     private static final String FCM_FIREBASE_APP_NAME = "com.urbanairship.fcm_firebase_app_name";
 
     private static final String NOTIFICATION_OPT_IN_STATUS_EVENT_PREFERENCES_KEY = "com.urbanairship.notification_opt_in_status_preferences";
-    private static final String DEFAULT_NOTIFICATION_CHANNEL_ID  = "com.urbanairship.default_notification_channel_id";
+    private static final String DEFAULT_NOTIFICATION_CHANNEL_ID = "com.urbanairship.default_notification_channel_id";
+    private static final String FOREGROUND_NOTIFICATIONS = "com.urbanairship.foreground_notifications";
 
     private static PluginManager instance;
     private final Object lock = new Object();
@@ -177,6 +178,7 @@ public class PluginManager {
 
     /**
      * Gets the default notification channel ID.
+     *
      * @return The default notification channel ID.
      */
     @Nullable
@@ -184,8 +186,12 @@ public class PluginManager {
         return sharedPreferences.getString(DEFAULT_NOTIFICATION_CHANNEL_ID, null);
     }
 
-     public boolean getUseCustomPreferenceCenterUi(@NonNull String preferenceCenterId) {
+    public boolean getUseCustomPreferenceCenterUi(@NonNull String preferenceCenterId) {
         return sharedPreferences.getBoolean(useCustomPreferenceCenterUiKey(preferenceCenterId), false);
+    }
+
+    public boolean isForegroundNotificationsEnabled() {
+        return sharedPreferences.getBoolean(FOREGROUND_NOTIFICATIONS, true);
     }
 
     private static String useCustomPreferenceCenterUiKey(@NonNull String preferenceCenterId) {
@@ -476,7 +482,7 @@ public class PluginManager {
             try {
                 return Color.parseColor(color);
             } catch (IllegalArgumentException e) {
-                PluginLogger.error( e, "Unable to parse color: %s", color);
+                PluginLogger.error(e, "Unable to parse color: %s", color);
             }
         }
         return defaultColor;
@@ -560,7 +566,7 @@ public class PluginManager {
         @NonNull
         public ConfigEditor setProductionConfig(@NonNull String appKey, @NonNull String appSecret) {
             editor.putString(PRODUCTION_KEY, appKey)
-                  .putString(PRODUCTION_SECRET, appSecret);
+                    .putString(PRODUCTION_SECRET, appSecret);
             return this;
         }
 
@@ -574,7 +580,7 @@ public class PluginManager {
         @NonNull
         public ConfigEditor setDevelopmentConfig(@NonNull String appKey, @NonNull String appSecret) {
             editor.putString(DEVELOPMENT_KEY, appKey)
-                  .putString(DEVELOPMENT_SECRET, appSecret);
+                    .putString(DEVELOPMENT_SECRET, appSecret);
             return this;
         }
 
@@ -651,6 +657,12 @@ public class PluginManager {
         @NonNull
         public ConfigEditor setAutoLaunchMessageCenter(boolean autoLaunchMessageCenter) {
             editor.putString(AUTO_LAUNCH_MESSAGE_CENTER, Boolean.toString(autoLaunchMessageCenter));
+            return this;
+        }
+
+        @NonNull
+        public ConfigEditor setForegroundNotificationsEnabled(boolean allow) {
+            editor.putString(FOREGROUND_NOTIFICATIONS, Boolean.toString(allow));
             return this;
         }
 

--- a/urbanairship-cordova/src/android/PluginManager.java
+++ b/urbanairship-cordova/src/android/PluginManager.java
@@ -662,7 +662,7 @@ public class PluginManager {
 
         @NonNull
         public ConfigEditor setForegroundNotificationsEnabled(boolean allow) {
-            editor.putString(FOREGROUND_NOTIFICATIONS, Boolean.toString(allow));
+            editor.putBoolean(FOREGROUND_NOTIFICATIONS, allow);
             return this;
         }
 

--- a/urbanairship-cordova/src/android/UAirshipPlugin.java
+++ b/urbanairship-cordova/src/android/UAirshipPlugin.java
@@ -88,7 +88,8 @@ public class UAirshipPlugin extends CordovaPlugin {
             "deleteInboxMessage", "getInboxMessages", "displayInboxMessage", "refreshInbox", "getDeepLink", "setAssociatedIdentifier",
             "isAppNotificationsEnabled", "dismissMessageCenter", "dismissInboxMessage", "setAutoLaunchDefaultMessageCenter",
             "getActiveNotifications", "clearNotification", "editChannelAttributes", "editNamedUserAttributes", "trackScreen",
-            "enableFeature", "disableFeature", "setEnabledFeatures", "getEnabledFeatures", "isFeatureEnabled", "openPreferenceCenter", "getPreferenceCenterConfig", "setUseCustomPreferenceCenterUi");
+            "enableFeature", "disableFeature", "setEnabledFeatures", "getEnabledFeatures", "isFeatureEnabled", "openPreferenceCenter",
+            "getPreferenceCenterConfig", "setUseCustomPreferenceCenterUi", "setForegroundNotificationsEnabled");
 
     /*
      * These actions are available even if airship is not ready.
@@ -288,6 +289,8 @@ public class UAirshipPlugin extends CordovaPlugin {
                         getPreferenceCenterConfig(data, callbackContext);
                     } else if ("setUseCustomPreferenceCenterUi".equals(action)) {
                         setUseCustomPreferenceCenterUi(data, callbackContext);
+                    } else if ("setForegroundNotificationsEnabled".equals(action)) {
+                        setForegroundNotificationsEnabled(data, callbackContext);
                     } else {
                         PluginLogger.debug("No implementation for action: %s", action);
                         callbackContext.error("No implementation for action " + action);
@@ -1524,6 +1527,14 @@ public class UAirshipPlugin extends CordovaPlugin {
         boolean useCustomUi = data.getBoolean(1);
         pluginManager.editConfig()
                 .setUseCustomPreferenceCenterUi(preferenceCenterId, useCustomUi)
+                .apply();
+        callbackContext.success();
+    }
+
+    private void setForegroundNotificationsEnabled(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
+        boolean enabled = data.getBoolean(0);
+        pluginManager.editConfig()
+                .setForegroundNotificationsEnabled(enabled)
                 .apply();
         callbackContext.success();
     }

--- a/urbanairship-cordova/src/android/UAirshipPlugin.java
+++ b/urbanairship-cordova/src/android/UAirshipPlugin.java
@@ -89,7 +89,7 @@ public class UAirshipPlugin extends CordovaPlugin {
             "isAppNotificationsEnabled", "dismissMessageCenter", "dismissInboxMessage", "setAutoLaunchDefaultMessageCenter",
             "getActiveNotifications", "clearNotification", "editChannelAttributes", "editNamedUserAttributes", "trackScreen",
             "enableFeature", "disableFeature", "setEnabledFeatures", "getEnabledFeatures", "isFeatureEnabled", "openPreferenceCenter",
-            "getPreferenceCenterConfig", "setUseCustomPreferenceCenterUi", "setForegroundNotificationsEnabled");
+            "getPreferenceCenterConfig", "setUseCustomPreferenceCenterUi", "setAndroidForegroundNotificationsEnabled");
 
     /*
      * These actions are available even if airship is not ready.
@@ -289,7 +289,7 @@ public class UAirshipPlugin extends CordovaPlugin {
                         getPreferenceCenterConfig(data, callbackContext);
                     } else if ("setUseCustomPreferenceCenterUi".equals(action)) {
                         setUseCustomPreferenceCenterUi(data, callbackContext);
-                    } else if ("setForegroundNotificationsEnabled".equals(action)) {
+                    } else if ("setAndroidForegroundNotificationsEnabled".equals(action)) {
                         setForegroundNotificationsEnabled(data, callbackContext);
                     } else {
                         PluginLogger.debug("No implementation for action: %s", action);

--- a/urbanairship-cordova/src/android/Utils.java
+++ b/urbanairship-cordova/src/android/Utils.java
@@ -3,6 +3,7 @@
 package com.urbanairship.cordova;
 
 import android.os.Bundle;
+import android.os.Message;
 import android.service.notification.StatusBarNotification;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,6 +16,7 @@ import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Utility methods.
@@ -76,7 +78,11 @@ public class Utils {
         data.putOpt("title", message.getTitle());
         data.putOpt("subtitle", message.getSummary());
         data.putOpt("extras", new JSONObject(extras));
-        data.putOpt("actions", new JSONObject(message.getActions()));
+
+        String actions = message.getExtra(PushMessage.EXTRA_ACTIONS);
+        if (actions != null) {
+            data.putOpt("actions", new JSONObject(actions));
+        }
 
         if (notificationId != null) {
             data.putOpt("notification_id", notificationId);

--- a/urbanairship-cordova/src/android/Utils.java
+++ b/urbanairship-cordova/src/android/Utils.java
@@ -76,6 +76,7 @@ public class Utils {
         data.putOpt("title", message.getTitle());
         data.putOpt("subtitle", message.getSummary());
         data.putOpt("extras", new JSONObject(extras));
+        data.putOpt("actions", new JSONObject(message.getActions()));
 
         if (notificationId != null) {
             data.putOpt("notification_id", notificationId);

--- a/urbanairship-cordova/src/ios/events/UACordovaPushEvent.m
+++ b/urbanairship-cordova/src/ios/events/UACordovaPushEvent.m
@@ -33,7 +33,7 @@ NSString *const EventPushReceived = @"urbanairship.push";
         [info removeObjectForKey:@"_"];
     }
 
-    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];;
 
     // If there is an aps dictionary in the extras, remove it and set it as a top level object
     if([[info allKeys] containsObject:@"aps"]) {
@@ -63,8 +63,23 @@ NSString *const EventPushReceived = @"urbanairship.push";
         [info removeObjectForKey:@"aps"];
     }
 
+    NSMutableDictionary *actions = [NSMutableDictionary dictionary];
+    for (id key in info.allKeys) {
+        if (![key isKindOfClass:[NSString class]]) {
+            continue;
+        }
+
+        if ([UAirship.shared.actionRegistry registryEntryWithName:key]) {
+            actions[key] = info[key];
+        }
+    }
+
+    result[@"actions"] = actions;
+
     // Set the remaining info as extras
     result[@"extras"] = info;
+
+
 
     return result;
 }

--- a/urbanairship-cordova/www/UrbanAirship.js
+++ b/urbanairship-cordova/www/UrbanAirship.js
@@ -1121,9 +1121,9 @@ module.exports = {
    * @param {function(message)} [failure] Failure callback.
    * @param {string} failure.message The error message.
    */
-   setAndroidForegroundNotificationsEnabled: function(options, success, failure) {
+   setAndroidForegroundNotificationsEnabled: function(enabled, success, failure) {
      argscheck.checkArgs('*FF', 'UAirship.setAndroidForegroundNotificationsEnabled', arguments)
-     callNative(success, failure, "setForegroundNotificationsEnabled", [!!enabled])
+     callNative(success, failure, "setAndroidForegroundNotificationsEnabled", [!!enabled])
    },
 
   /**

--- a/urbanairship-cordova/www/UrbanAirship.js
+++ b/urbanairship-cordova/www/UrbanAirship.js
@@ -1113,6 +1113,19 @@ module.exports = {
      callNative(success, failure, "setPresentationOptions", [options])
    },
 
+   /**
+   * Enables/Disables foreground notifications display on Android.
+   *
+   * @param {Boolean} enabled true to enable foreground notifications, false to disable.
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   */
+   setAndroidForegroundNotificationsEnabled: function(options, success, failure) {
+     argscheck.checkArgs('*FF', 'UAirship.setAndroidForegroundNotificationsEnabled', arguments)
+     callNative(success, failure, "setForegroundNotificationsEnabled", [!!enabled])
+   },
+
   /**
    * Enum for notification types.
    * @readonly


### PR DESCRIPTION
Adds actions to the push message and a way to enable/disable foreground display on Android. Verified on iOS and Android.

We should eventually add the foreground control flag to the Android SDK.