### PR TITLE
[MOBILE-3060] Add locale override methods

### DIFF
--- a/urbanairship-cordova/src/android/UAirshipPlugin.java
+++ b/urbanairship-cordova/src/android/UAirshipPlugin.java
@@ -89,7 +89,7 @@ public class UAirshipPlugin extends CordovaPlugin {
             "isAppNotificationsEnabled", "dismissMessageCenter", "dismissInboxMessage", "setAutoLaunchDefaultMessageCenter",
             "getActiveNotifications", "clearNotification", "editChannelAttributes", "editNamedUserAttributes", "trackScreen",
             "enableFeature", "disableFeature", "setEnabledFeatures", "getEnabledFeatures", "isFeatureEnabled", "openPreferenceCenter",
-            "getPreferenceCenterConfig", "setUseCustomPreferenceCenterUi", "setAndroidForegroundNotificationsEnabled");
+            "getPreferenceCenterConfig", "setUseCustomPreferenceCenterUi", "setAndroidForegroundNotificationsEnabled", "setCurrentLocale", "getCurrentLocale", "clearLocale");
 
     /*
      * These actions are available even if airship is not ready.
@@ -291,6 +291,12 @@ public class UAirshipPlugin extends CordovaPlugin {
                         setUseCustomPreferenceCenterUi(data, callbackContext);
                     } else if ("setAndroidForegroundNotificationsEnabled".equals(action)) {
                         setForegroundNotificationsEnabled(data, callbackContext);
+                    } else if ("setCurrentLocale".equals(action)) {
+                        setCurrentLocale(data, callbackContext);
+                    } else if ("getCurrentLocale".equals(action)) {
+                        getCurrentLocale(data, callbackContext);
+                    } else if ("clearLocale".equals(action)) {
+                        clearLocale(data, callbackContext);
                     } else {
                         PluginLogger.debug("No implementation for action: %s", action);
                         callbackContext.error("No implementation for action " + action);
@@ -1536,6 +1542,39 @@ public class UAirshipPlugin extends CordovaPlugin {
         pluginManager.editConfig()
                 .setForegroundNotificationsEnabled(enabled)
                 .apply();
+        callbackContext.success();
+    }
+    
+    /**
+     * Overriding the locale.
+     *
+     *  @param data  The call data.
+     *  @throws JSONException
+     */
+    private void setCurrentLocale(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
+        String localeIdentifier = data.getString(0);
+        UAirship.shared().setLocaleOverride(new Locale(localeIdentifier));
+        callbackContext.success();
+    }
+
+    /**
+     * Getting the locale currently used by Airship.
+     *  @param callbackContext The callback context.
+     *  @throws JSONException
+     */
+       
+    private void getCurrentLocale(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
+        Locale airshipLocale = UAirship.shared().getLocale();
+        callbackContext.success(airshipLocale.getLanguage());
+    }
+
+    /**
+     * Resets the current locale.
+     *  @param callbackContext The callback context.
+     *  @throws JSONException
+     */
+    private void clearLocale(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
+        UAirship.shared().setLocaleOverride(null);
         callbackContext.success();
     }
 

--- a/urbanairship-cordova/src/ios/UAirshipPlugin.h
+++ b/urbanairship-cordova/src/ios/UAirshipPlugin.h
@@ -511,4 +511,23 @@
  */
 - (void)getContactSubscriptionLists:(CDVInvokedUrlCommand *)command;
 
+/**
+ * Returns the locale currently used by Airship.
+ * @param command The cordova command.
+ */
+- (void)getCurrentLocale:(CDVInvokedUrlCommand *)command;
+
+/**
+ * Overrides the locale.
+ * @param command The cordova command.
+ */
+- (void)setCurrentLocale:(CDVInvokedUrlCommand *)command;
+
+/**
+ * Resets the current locale.
+ *
+ * @param command The cordova command.
+ */
+- (void)clearLocale:(CDVInvokedUrlCommand *)command ;
+
 @end

--- a/urbanairship-cordova/src/ios/UAirshipPlugin.m
+++ b/urbanairship-cordova/src/ios/UAirshipPlugin.m
@@ -1117,6 +1117,31 @@ typedef void (^UACordovaExecutionBlock)(NSArray *args, UACordovaCompletionHandle
     }];
 }
 
+- (void)getCurrentLocale:(CDVInvokedUrlCommand *)command {
+    UA_LTRACE("getCurrentLocale called with command arguments: %@", command.arguments);
+    [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
+        NSLocale *airshipLocale = [[UAirship shared].localeManager currentLocale];
+        completionHandler(CDVCommandStatus_OK, airshipLocale.localeIdentifier);
+    }];
+}
+
+- (void)setCurrentLocale:(CDVInvokedUrlCommand *)command {
+    UA_LTRACE("setCurrentLocale called with command arguments: %@", command.arguments);
+    [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
+        NSString *localeIdentifier = [args firstObject];
+        [UAirship.shared.localeManager setCurrentLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier]];
+        completionHandler(CDVCommandStatus_OK, nil);
+    }];
+}
+
+- (void)clearLocale:(CDVInvokedUrlCommand *)command {
+    UA_LTRACE("clearLocale called with command arguments: %@", command.arguments);
+    [self performCallbackWithCommand:command withBlock:^(NSArray *args, UACordovaCompletionHandler completionHandler) {
+        [[UAirship shared].localeManager clearLocale];
+        completionHandler(CDVCommandStatus_OK, nil);
+    }];
+}
+
 - (BOOL)isValidFeature:(NSArray *)features {
     if (!features || [features count] == 0) {
         return NO;

--- a/urbanairship-cordova/www/UrbanAirship.js
+++ b/urbanairship-cordova/www/UrbanAirship.js
@@ -1369,4 +1369,37 @@ module.exports = {
       callNative(success, failure, "setUseCustomPreferenceCenterUi", [preferenceCenterId, useCustomUi]);
     }
 
+    /**
+      * Overriding the locale.
+      *
+      * @param {string} localeIdentifier The locale identifier.
+      */
+     setCurrentLocale: function(localeIdentifier, success, failure) {
+         argscheck.checkArgs("sFF", "UAirship.setCurrentLocale", arguments);
+         callNative(success, failure, "setCurrentLocale", [localeIdentifier]);
+     }
+
+     /**
+      * Getting the locale currently used by Airship.
+      *
+      * @param {function} [success] Success callback.
+      * @param {string} failure.message The error message.
+      */
+     getCurrentLocale: function(success, failure) {
+         argscheck.checkArgs('fF', 'UAirship.getCurrentLocale', arguments)
+         callNative(success, failure, "getCurrentLocale")
+     }
+
+     /**
+      * Resets the current locale.
+      *
+      * @param {function} [success] Success callback.
+      * @param {function(message)} [failure] Failure callback.
+      * @param {string} failure.message The error message.
+      */
+     clearLocale: function(success, failure) {
+         argscheck.checkArgs('FF', 'UAirship.clearLocale', arguments)
+         callNative(success, failure, "clearLocale")
+     }
+
 }


### PR DESCRIPTION
### What do these changes do?
This PR adds locale override methods: setCurrentLocale, getCurrentLocale and resetLocale.

### Why are these changes necessary?
Matching other frameworks + customer demand

### How did you verify these changes?
Tested manually.


