### PR TITLE
Release 14.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Cordova Plugin Changelog
 
-## Version 14.10.0 - Jun 14, 2023
+## Version 14.10.1 - June 23, 2023
+Patch release that fixes a crash if takeOff is called with invalid config on Android.
+
+### Changes
+- Fix crash due to an invalid config exception on Android
+
+## Version 14.10.0 - June 14, 2023
 Minor release that updates the iOS SDK to 16.12.1 and the Android SDK to 16.11.1.
 
 ### Changes

--- a/urbanairship-accengage-cordova/package.json
+++ b/urbanairship-accengage-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-cordova",
-  "version": "14.10.0",
+  "version": "14.10.1",
   "description": "Urban Airship-Accengage Cordova plugin",
   "cordova": {
     "id": "urbanairship-accengage-cordova",

--- a/urbanairship-accengage-cordova/plugin.xml
+++ b/urbanairship-accengage-cordova/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="urbanairship-accengage-cordova"
-        version="14.10.0"
+        version="14.10.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -16,13 +16,13 @@
         <engine name="cordova" version=">=9.0.1"/>
     </engines>
 
-    <dependency id="urbanairship-cordova" version="14.10.0"/>
+    <dependency id="urbanairship-cordova" version="14.10.1"/>
 
     <!-- ios -->
     <platform name="ios">
 
         <config-file target="*-Info.plist" parent="UACordovaPluginVersion">
-            <string>14.10.0</string>
+            <string>14.10.1</string>
         </config-file>
 
         <!-- Airship Accengage Module -->

--- a/urbanairship-cordova/package.json
+++ b/urbanairship-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-cordova",
-  "version": "14.10.0",
+  "version": "14.10.1",
   "description": "Urban Airship Cordova plugin",
   "cordova": {
     "id": "urbanairship-cordova",

--- a/urbanairship-cordova/plugin.xml
+++ b/urbanairship-cordova/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin id="urbanairship-cordova"
-        version="14.10.0"
+        version="14.10.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -40,7 +40,7 @@
         <config-file parent="/manifest/application" target="AndroidManifest.xml">
             <meta-data
                 android:name="com.urbanairship.cordova.version"
-                android:value="14.10.0"/>
+                android:value="14.10.1"/>
 
             <meta-data
                 android:name="com.urbanairship.autopilot"
@@ -145,7 +145,7 @@
         </config-file>
 
         <config-file target="*-Info.plist" parent="UACordovaPluginVersion">
-            <string>14.10.0</string>
+            <string>14.10.1</string>
         </config-file>
 
         <config-file parent="/widget" target="config.xml">

--- a/urbanairship-cordova/src/android/PluginManager.java
+++ b/urbanairship-cordova/src/android/PluginManager.java
@@ -376,9 +376,12 @@ public class PluginManager {
         }
 
         try {
-            configOptions = builder.build();
+            AirshipConfigOptions config = builder.build();
+            config.validate();
+            configOptions = config;
             return configOptions;
         } catch (IllegalArgumentException e) {
+            PluginLogger.error(e, "Invalid AirshipConfig");
             return null;
         }
     }

--- a/urbanairship-hms-cordova/package.json
+++ b/urbanairship-hms-cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-hms-cordova",
-  "version": "14.10.0",
+  "version": "14.10.1",
   "description": "Urban Airship HMS Cordova plugin",
   "cordova": {
     "id": "urbanairship-hms-cordova",

--- a/urbanairship-hms-cordova/plugin.xml
+++ b/urbanairship-hms-cordova/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="urbanairship-hms-cordova"
-        version="14.10.0"
+        version="14.10.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -15,7 +15,7 @@
         <engine name="cordova" version=">=9.0.1"/>
     </engines>
 
-    <dependency id="urbanairship-cordova" version="14.10.0"/>
+    <dependency id="urbanairship-cordova" version="14.10.1"/>
 
     <!-- android -->
     <platform name="android">


### PR DESCRIPTION
Fixes a crash on Android if takeOff is called with invalid config. We already validate the config on iOS so this is just an Android issue. Logging/error could be improved but I believe thats already the case in the proxy framework, so this is a quick fix for now until we move cordova over to the proxy.